### PR TITLE
(#218) Support recording the route

### DIFF
--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -469,6 +469,19 @@ module MCollective
         Puppet.settings[setting]
       end
 
+      # Creates a SSL Context which includes the AIO SSL files
+      #
+      # @return [OpenSSL::SSL::SSLContext]
+      def ssl_context
+        context = OpenSSL::SSL::SSLContext.new
+        context.ca_file = ca_path
+        context.cert = OpenSSL::X509::Certificate.new(File.read(client_public_cert))
+        context.key = OpenSSL::PKey::RSA.new(File.read(client_private_key))
+        context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+        context
+      end
+
       # The directory where SSL related files live
       #
       # This is configurable using choria.ssldir which should be a

--- a/spec/unit/mcollective/util/choria_spec.rb
+++ b/spec/unit/mcollective/util/choria_spec.rb
@@ -7,6 +7,21 @@ module MCollective
       let(:choria) { Choria.new("production", nil, false) }
       let(:parsed_app) { JSON.parse(File.read("spec/fixtures/sample_app.json")) }
 
+      describe "#ssl_context" do
+        it "should create a valid ssl context" do
+          choria.stubs(:ca_path).returns("spec/fixtures/ca_crt.pem")
+          choria.stubs(:client_public_cert).returns("spec/fixtures/rip.mcollective.pem")
+          choria.stubs(:client_private_key).returns("spec/fixtures/rip.mcollective.key")
+
+          context = choria.ssl_context
+
+          expect(context.verify_mode).to be(OpenSSL::SSL::VERIFY_PEER)
+          expect(context.ca_file).to eq("spec/fixtures/ca_crt.pem")
+          expect(context.cert.subject.to_s).to eq("/CN=rip.mcollective")
+          expect(context.key.to_pem).to eq(File.read("spec/fixtures/rip.mcollective.key"))
+        end
+      end
+
       describe "#federation_networks" do
         it "should correctly interpret federations config" do
           Config.instance.stubs(:pluginconf).returns("choria.federation.networks" => "          ")


### PR DESCRIPTION
This adds an option nats.record_route that manages a headers "seen-by"
which lists the connector the message enters and leaves on

Close #218 