### PR TITLE
(#220) Use unique config and SRV for federation NATS

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -64,6 +64,7 @@ task :release do
   sh("rm -rf module/files/mcollective/*")
   sh("cp -rv lib/mcollective/* module/files/mcollective/")
   sh("cp CHANGELOG.md COPYING module")
+  sh("cp .gitignore module")
   Dir.chdir("module") do
     sh("/opt/puppetlabs/bin/puppet module build")
   end

--- a/module/.gitignore
+++ b/module/.gitignore
@@ -1,0 +1,11 @@
+*.swp
+.yardoc
+doc
+module/files/mcollective
+module/pkg
+module/CHANGELOG.md
+module/COPYING
+tmp
+coverage
+website/public
+*.bak


### PR DESCRIPTION
Uses choria.federation_middleware_hosts and SRV records "_mcollective-federation_server._tcp",
or "_x-puppet-mcollective_federation._tcp" for finding brokers to talk
to federations with, if none found falls back to normal servers