### PR TITLE
(#225) Make the federation broker targets unique

### DIFF
--- a/lib/mcollective/connector/nats.rb
+++ b/lib/mcollective/connector/nats.rb
@@ -234,7 +234,7 @@ module MCollective
 
         choria.federation_collectives.each do |network|
           messages.each do |data|
-            network_target = "federation.network.%s" % network
+            network_target = "choria.federation.%s.federation" % network
 
             Log.debug("Sending a federated direct message via NATS target '%s' for message type %s" % [target.inspect, msg.type])
 
@@ -278,7 +278,7 @@ module MCollective
         data = JSON.dump(data)
 
         choria.federation_collectives.each do |network|
-          target[:name] = "federation.network.%s" % network
+          target[:name] = "choria.federation.%s.federation" % network
 
           Log.debug("Sending a federated broadcast message to NATS target '%s' for message type %s" % [target.inspect, msg.type])
 

--- a/spec/unit/mcollective/connector/nats_spec.rb
+++ b/spec/unit/mcollective/connector/nats_spec.rb
@@ -220,8 +220,8 @@ module MCollective
 
         JSON.expects(:dump).with(msg1).returns("msg_1")
 
-        connection.expects(:publish).with("federation.network.net_a", "msg_1", "mcollective.reply.rspec_identity.999999.0")
-        connection.expects(:publish).with("federation.network.net_b", "msg_1", "mcollective.reply.rspec_identity.999999.0")
+        connection.expects(:publish).with("choria.federation.net_a.federation", "msg_1", "mcollective.reply.rspec_identity.999999.0")
+        connection.expects(:publish).with("choria.federation.net_b.federation", "msg_1", "mcollective.reply.rspec_identity.999999.0")
 
         connector.publish_federated_broadcast(msg)
       end
@@ -262,10 +262,10 @@ module MCollective
         JSON.expects(:dump).with(msg1).returns("msg_1")
         JSON.expects(:dump).with(msg2).returns("msg_2")
 
-        connection.expects(:publish).with("federation.network.net_a", "msg_1", "mcollective.reply.rspec_identity.999999.0")
-        connection.expects(:publish).with("federation.network.net_a", "msg_2", "mcollective.reply.rspec_identity.999999.0")
-        connection.expects(:publish).with("federation.network.net_b", "msg_1", "mcollective.reply.rspec_identity.999999.0")
-        connection.expects(:publish).with("federation.network.net_b", "msg_2", "mcollective.reply.rspec_identity.999999.0")
+        connection.expects(:publish).with("choria.federation.net_a.federation", "msg_1", "mcollective.reply.rspec_identity.999999.0")
+        connection.expects(:publish).with("choria.federation.net_a.federation", "msg_2", "mcollective.reply.rspec_identity.999999.0")
+        connection.expects(:publish).with("choria.federation.net_b.federation", "msg_1", "mcollective.reply.rspec_identity.999999.0")
+        connection.expects(:publish).with("choria.federation.net_b.federation", "msg_2", "mcollective.reply.rspec_identity.999999.0")
 
         connector.publish_federated_directed(msg)
       end


### PR DESCRIPTION
Previously the federation and collective sides of the Federation Broker
was going to use the same queue name, this is a mistake as it makes
development and deployments for reasons other than scale too complex

They will now use choria.federation.fed_name.federation