### PR TITLE
(#228) Add a Federation Broker

### DIFF
--- a/lib/mcollective/application/federation.rb
+++ b/lib/mcollective/application/federation.rb
@@ -1,0 +1,165 @@
+module MCollective
+  class Application
+    class Federation < Application
+      description "Choria Federation Brokers"
+
+      usage <<-EOU
+mco federation [OPTIONS] <ACTION>
+
+The ACTION can be one of the following:
+
+   observe       - view the published Federation Broker statistics
+   broker        - start a Federation Broker instance
+
+EOU
+
+      exclude_argument_sections "common", "filter", "rpc"
+
+      option :cluster,
+             :arguments => ["--cluster CLUSTER"],
+             :description => "Cluster name to observe or serve",
+             :type => String
+
+      option :instance,
+             :arguments => ["--instance INSTANCE"],
+             :description => "Instance name to observe or serve",
+             :type => String
+
+      option :stats_port,
+             :arguments => ["--stats-port PORT", "--stats"],
+             :description => "HTTP port to listen to for stats",
+             :type => Integer
+
+      def broker_command
+        configuration[:cluster] = Config.instance.pluginconf["choria.federation.cluster"] unless configuration[:cluster]
+        configuration[:instance] = Config.instance.pluginconfig["choria.federation.instance"] unless configuration[:instance]
+
+        abort("A cluster name is required, use --cluster or plugin.choria.federation.cluster") unless configuration[:cluster]
+
+        Log.warn("Using a UUID based instance name, use --instance of plugin.choria.federation.instance") unless configuration[:instance]
+
+        broker = MCollective::Util::FederationBroker.new(
+          configuration[:cluster],
+          configuration[:instance],
+          configuration[:stats_port]
+        )
+
+        broker.start
+
+        sleep 10 while broker.ok?
+
+        Log.error("Some broker threads crashed, exiting")
+        Log.error(broker.thread_status.pretty_inspect)
+
+        exit(1)
+      rescue Interrupt
+        exit
+      end
+
+      def observe_command
+        puts "Waiting for cluster stats to be published ...."
+
+        Util::FederationBroker.new(configuration[:cluster]).observe_stats do |stats|
+          next if stats.empty?
+
+          print "\e[H\e[2J"
+
+          puts "Federation Broker: %s" % Util.colorize(:bold, configuration[:cluster])
+          puts
+
+          ["collective", "federation"].each do |type|
+            type_stats = {"sent" => 0, "received" => 0, "instances" => {}}
+
+            stats.keys.sort.each do |instance|
+              type_stats["sent"] += stats[instance][type]["sent"]
+              type_stats["received"] += stats[instance][type]["received"]
+              type_stats["instances"][instance] ||= {}
+              type_stats["instances"][instance][type] = {
+                "sent" => stats[instance][type]["sent"],
+                "received" => stats[instance][type]["received"],
+                "last" => stats[instance][type]["lasst_message"]
+              }
+            end
+
+            puts "%s" % Util.colorize(:bold, type.capitalize)
+            puts "  Totals:"
+            puts "    Received: %d  Sent: %d" % [type_stats["received"], type_stats["sent"]]
+            puts
+            puts "  Instances:"
+
+            padding = type_stats["instances"].keys.map(&:length).max + 4
+
+            type_stats["instances"].keys.sort.each do |instance|
+              puts "%#{padding}s: Received: %d (%.1f%%) Sent: %d (%.1f%%)" % [
+                instance,
+                type_stats["instances"][instance][type]["received"],
+                type_stats["instances"][instance][type]["received"] / type_stats["received"].to_f * 100,
+                type_stats["instances"][instance][type]["sent"],
+                type_stats["instances"][instance][type]["sent"] / type_stats["sent"].to_f * 100
+              ]
+            end
+
+            puts
+          end
+
+          puts Util.colorize(:bold, "Instances:")
+
+          stats.keys.sort.each do |instance|
+            puts "  %s version %s started %s" % [
+              instance,
+              stats[instance]["version"],
+              Time.at(stats[instance]["start_time"]).strftime("%F %T")
+            ]
+          end
+
+          puts
+          puts "Updated: %s" % Time.now.strftime("%F %T")
+        end
+      rescue Interrupt
+        exit
+      end
+
+      # Creates and cache a Choria helper class
+      #
+      # @return [Util::Choria]
+      def choria
+        @_choria ||= Util::Choria.new
+      end
+
+      def post_option_parser(configuration)
+        if ARGV.length >= 1
+          configuration[:command] = ARGV.shift
+        else
+          abort("Please specify a command, valid commands are: %s" % valid_commands.join(", "))
+        end
+      end
+
+      def validate_configuration(configuration)
+        Util.loadclass("MCollective::Util::Choria")
+
+        unless valid_commands.include?(configuration[:command])
+          abort("Unknown command %s, valid commands are: %s" % [configuration[:command], valid_commands.join(", ")])
+        end
+
+        if !choria.has_client_public_cert? && !["request_cert", "show_config"].include?(configuration[:command])
+          abort("A certificate is needed from the Puppet CA for `%s`, please use the `request_cert` command" % choria.certname)
+        end
+
+        if configuration[:command] == "observe"
+          abort("When observing a Federation Broker the --cluster option is required") unless configuration[:cluster]
+        end
+      end
+
+      def main
+        send("%s_command" % configuration[:command])
+      end
+
+      # List of valid commands this application respond to
+      #
+      # @return [Array<String>] like `plan` and `run`
+      def valid_commands
+        methods.grep(/_command$/).map {|c| c.to_s.gsub("_command", "")}
+      end
+    end
+  end
+end

--- a/lib/mcollective/connector/nats.rb
+++ b/lib/mcollective/connector/nats.rb
@@ -355,7 +355,7 @@ module MCollective
           end
         end
 
-        if Util.str_to_bool(get_option("nats.record_route", "n"))
+        if choria.record_nats_route?
           headers = msg["headers"]
           (headers["seen-by"] ||= []) << connected_server
         end

--- a/lib/mcollective/util/federation_broker.rb
+++ b/lib/mcollective/util/federation_broker.rb
@@ -1,0 +1,139 @@
+require_relative "choria"
+require_relative "natswrapper"
+require_relative "federation_broker/stats"
+require_relative "federation_broker/base"
+require_relative "federation_broker/collective_processor"
+require_relative "federation_broker/federation_processor"
+
+module MCollective
+  module Util
+    class FederationBroker
+      attr_reader :cluster_name, :instance_name, :stats, :processors, :connections
+
+      # @private
+      attr_reader :threads, :choria
+
+      # @param cluster_name [String] the name of the federation broker cluster
+      # @param instance_name [String, nil] the name of this specific instance in the cluster
+      # @param stats_port [Integer] the port to listen to for stats, uses choria.stats_port when nil
+      def initialize(cluster_name, instance_name=nil, stats_port=nil)
+        @started = false
+
+        @processors_lock = Mutex.new
+        @threads_lock = Mutex.new
+
+        @threads = {}
+        @processors = {}
+        @connections = {}
+
+        @cluster_name = cluster_name
+        @instance_name = instance_name || SSL.uuid
+
+        @stats_port = stats_port
+        @choria = Choria.new(nil, nil, false)
+        @config = Config.instance
+        @stats = Stats.new(self)
+
+        @to_federation = Queue.new
+        @to_collective = Queue.new
+      end
+
+      # The port used to listen on for HTTP stats requests
+      #
+      # @see Choria#start_port
+      # @return [Integer,nil]
+      def stats_port
+        @stats_port || @choria.stats_port
+      end
+
+      # Stores a thread in the global thread list
+      #
+      # Threads stored here will be checked via {#ok?}
+      # and reports in stats via {#thread_status}
+      #
+      # @param name [String]
+      # @param thread [Thread]
+      # @raise [StandardError] when a thread by that name exist already
+      def record_thread(name, thread)
+        @threads_lock.synchronize do
+          raise("Thread called '%s' already exist in the thread registry" % name) if @threads.include?(name)
+          @threads[name] = thread
+          @threads[name]["_name"] = name
+        end
+      end
+
+      # Determines if the Broker has been started
+      #
+      # @return [Boolean]
+      def started?
+        @started
+      end
+
+      # Determines if all the threads are alive
+      #
+      # @todo just a alive? check isnt enough, workers should have some introspection
+      # @return [Boolean]
+      def ok?
+        @threads_lock.synchronize { @threads.all? {|_, thr| thr.alive?} }
+      end
+
+      # Status for all component threads
+      #
+      # @return [Hash] of `alive` and `status` for every thread
+      def thread_status
+        @threads_lock.synchronize do
+          Hash[@threads.map do |name, thread|
+            [name, "alive" => thread.alive?, "status" => thread.status]
+          end]
+        end
+      end
+
+      # Connect to the federation and observes published stats
+      #
+      # This will yield a hash of stats for every instance in the
+      # Federation Broker in {@cluster_name}
+      def observe_stats
+        ENV["CHORIA_FED_COLLECTIVE"] = @cluster_name
+
+        servers = Choria.new(nil, nil, false).middleware_servers("puppet", "4222").map do |host, port|
+          URI("nats://%s:%s" % [host, port])
+        end.map(&:to_s)
+
+        lock = Mutex.new
+
+        cluster_stats = {}
+
+        federation = FederationProcessor.new(self)
+        federation.start_connection(servers)
+
+        Thread.new do
+          federation.consume_from(:name => stats.stats_target) do |msg|
+            stats = JSON.parse(msg)
+
+            if stats["cluster"] == @cluster_name
+              lock.synchronize { cluster_stats[stats["instance"]] = stats }
+            end
+          end
+        end
+
+        loop do
+          lock.synchronize { yield(cluster_stats) }
+          sleep 1
+        end
+      end
+
+      # Starts the broker
+      #
+      # @note this method is non blocking, the federation continues to run in the background in threads
+      def start
+        @processors["collective"] = CollectiveProcessor.new(self, @to_collective, @to_federation)
+        @processors["federation"] = FederationProcessor.new(self, @to_federation, @to_collective)
+
+        @connections["collective"] = @processors["collective"].start
+        @connections["federation"] = @processors["federation"].start
+
+        @started = true
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/federation_broker/base.rb
+++ b/lib/mcollective/util/federation_broker/base.rb
@@ -1,0 +1,297 @@
+module MCollective
+  module Util
+    class FederationBroker
+      class Base
+        # @private
+        attr_reader :connection, :choria, :config
+
+        # @param broker [FederationBroker]
+        # @param inbox [Queue] connection from the other Processor
+        # @param outbox [Queue] connection to the other Processor
+        # @return [Base]
+        def initialize(broker, inbox=nil, outbox=nil)
+          @broker = broker
+          @outbox = outbox
+          @inbox = inbox
+          @config = Config.instance
+          @connection = Util::NatsWrapper.new
+          @choria = Choria.new(nil, nil, false)
+        end
+
+        def local_stats
+          @stats ||= {
+            "source" => queue[:name],
+            "received" => 0,
+            "sent" => 0,
+            "last_message" => 0,
+            "connected_server" => "disconnected"
+          }
+        end
+
+        # List of servers to connect to
+        #
+        # @abstract
+        # @return [Array<String>] list of servers in nats://host:port format
+        def servers
+          raise(NotImplementedError, "%s does not implement the #servers method" % [self.class])
+        end
+
+        # The type of processor this is
+        #
+        # @abstract
+        # @return ["collective", "federation"]
+        def processor_type
+          raise(NotImplementedError, "%s does not implement the #processor_type method" % [self.class])
+        end
+
+        # The queue to connect to
+        #
+        # @example
+        #     {
+        #       :name => "choria.production.federation",
+        #       :queue => "foo_federation"
+        #     }
+        #
+        # @abstract
+        # @return [Hash] with :queue and :name
+        def queue
+          raise(NotImplementedError, "%s does not implement the #queue method" % [self.class])
+        end
+
+        # Processor specific process logic
+        #
+        # @param msg [Hash] message from the wire
+        def process(msg)
+          raise(NotImplementedError, "%s does not implement the #process method" % [self.class])
+        end
+
+        # Processor statistics
+        #
+        # @return [Hash]
+        def stats
+          local_stats.merge(
+            "work_queue" => @inbox.size,
+            "connected_server" => connected_server
+          )
+        end
+
+        # NATS source for communicating with the Federation
+        #
+        # @return [String]
+        def federation_source_name
+          "choria.federation.%s.federation" % cluster_name
+        end
+
+        # NATS source for communicating with the collective
+        #
+        # @return [String]
+        def collective_source_name
+          "choria.federation.%s.collective" % cluster_name
+        end
+
+        # Records self in the seen-by headers
+        #
+        # Should the configuration to record full NATS path be set this
+        # will additionally record the connected NATS server
+        #
+        # @param headers [Hash]
+        def record_seen(headers)
+          headers["seen-by"] ||= []
+
+          if choria.record_nats_route?
+            headers["seen-by"] << connection.connected_server
+          end
+
+          headers["seen-by"] << "fedbroker_%s_%s" % [cluster_name, instance_name]
+        end
+
+        # Handled a specific inbox item
+        #
+        # @param item [Hash] item received from the other processor
+        # @raise [StandardError] for invalid items
+        def handle_inbox_item(item)
+          raise("Invalid item received: not a hash") unless item.is_a?(Hash)
+          raise("Invalid item received: :target not an array") unless item[:targets].is_a?(Array)
+          raise("Invalid item received: :data not a String") unless item[:data].is_a?(String)
+
+          item[:targets].each do |target|
+            local_stats["sent"] += 1
+            local_stats["last_message"] = Time.now.to_i
+
+            Log.info("%s publishing %s to %s" % [processor_type.capitalize, item[:req], target])
+
+            begin
+              connection.publish(target, item[:data])
+            rescue
+              @inbox << item
+              Log.error("Failed to publish from %s to %s: %s: %s" % [processor_type, item[:target], $!.class, $!.to_s])
+              raise
+            end
+          end
+        end
+
+        # Handler for message from the other Processor
+        #
+        # This will iterate over the Queue and publish any messages the other
+        # Processor wants published
+        def inbox_handler
+          thread = Thread.new do
+            begin
+              Log.info("Starting inbox handler for %s" % processor_type)
+
+              loop do
+                handle_inbox_item(@inbox.pop)
+              end
+            rescue
+              Log.error("%s inbox handler failed: %s: %s" % [processor_type, $!.class, $!.to_s])
+              Log.debug($!.join("\t\n"))
+
+              sleep 1
+
+              retry
+            end
+          end
+
+          @broker.record_thread("%s_inbox_handler" % processor_type, thread)
+        end
+
+        # The NATS server that this Processor is connected to
+        #
+        # @return [String] `disconnected` when not connected
+        def connected_server
+          connection.connected_server || "disconnected"
+        end
+
+        # The instance name of this Cluster member
+        #
+        # A Federation Broker can have many cluster members, each should
+        # ideally have unique names
+        #
+        # @return [String]
+        def instance_name
+          @broker.instance_name
+        end
+
+        # The Feradtion Broker cluster name
+        #
+        # This should be unique, any broker with the same cluster name
+        # will load share work.  This name is what a user configures in
+        # his client config as federation member names
+        #
+        # @return [String]
+        def cluster_name
+          @broker.cluster_name
+        end
+
+        # Starts the connection and traffic handlers
+        def start_connection_and_handlers
+          server_list = servers
+
+          Log.info("Starting Federation Broker %s Processor %s#%s against %s" % [processor_type, cluster_name, instance_name, server_list.to_s])
+
+          start_connection(server_list)
+          inbox_handler
+          consume
+        end
+
+        # Starts the NatsWrapper connection
+        #
+        # @param server_list [Array] list of servers, see {#servers}
+        def start_connection(server_list=nil)
+          server_list ||= servers
+
+          connection.start(default_nats_parameters.merge(:servers => server_list))
+        end
+
+        # Starts the main flow of the particular Processor
+        #
+        # This starts a middleware handler via {Util::NatsWrapper} and pass any messages received
+        # to the {#consume} message.  It also starts the {#inbox_handler}
+        #
+        # @return [NatsWrapper]
+        def start
+          thread = Thread.new do
+            begin
+              start_connection_and_handlers
+            rescue
+              Log.warn("%s Federation Broker failed: %s: %s" % [processor_type.capitalize, $!.class, $!.to_s])
+              Log.debug($!.backtrace.join("\n\t"))
+
+              connection.stop
+
+              sleep 1
+
+              retry
+            end
+          end
+
+          @broker.record_thread("%s_middleware_handler" % processor_type, thread)
+
+          connection
+        end
+
+        # Consumes message from the configured queue and connection
+        #
+        # This will call the {#process} method for every message received
+        # from the middleware
+        def consume
+          consume_from(queue) do |msg|
+            msg = JSON.parse(msg)
+
+            local_stats["received"] += 1
+            local_stats["last_message"] = Time.now.to_i
+
+            process(msg)
+          end
+        end
+
+        # Consumes messages from a specific queue and connection
+        #
+        # Any message received from the middleware is yielded to the given block
+        #
+        # @param queue [Hash] as produced by {#queue}
+        # @param block [Proc] block to call for every message
+        def consume_from(queue, &block)
+          Log.info("Starting consuming message from %s" % queue[:name])
+
+          begin
+            if queue[:queue]
+              connection.subscribe(queue[:name], :queue => queue[:queue])
+            else
+              connection.subscribe(queue[:name])
+            end
+
+          rescue
+            Log.warn("Subscribing to %s failed: %s: %s" % [queue[:name], $!.class, $!.to_s])
+            Log.debug($!.backtrace.join("\n\t"))
+            sleep 1
+            retry
+          end
+
+          loop do
+            begin
+              yield(connection.receive)
+            rescue
+              Log.warn("Failed while processing a message from %s: %s: %s" % [queue[:name], $!.class, $!.to_s])
+              Log.debug($!.backtrace.join("\n\t"))
+            end
+          end
+        end
+
+        # Default NATS connection parameters
+        #
+        # @return [Hash]
+        def default_nats_parameters
+          {
+            :max_reconnect_attempts => -1,
+            :reconnect_time_wait => 1,
+            :name => "fedbroker_%s_%s" % [cluster_name, instance_name],
+            :tls => {
+              :context => choria.ssl_context
+            }
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/federation_broker/collective_processor.rb
+++ b/lib/mcollective/util/federation_broker/collective_processor.rb
@@ -1,0 +1,57 @@
+require_relative "base"
+
+module MCollective
+  module Util
+    class FederationBroker
+      class CollectiveProcessor < Base
+        # @see Base#servers
+        def servers
+          choria.middleware_servers("puppet", "4222").map do |host, port|
+            URI("nats://%s:%s" % [host, port])
+          end.map(&:to_s)
+        end
+
+        # @see Base#processor_type
+        def processor_type
+          "collective"
+        end
+
+        # @see Base#queue
+        def queue
+          {
+            :name => collective_source_name,
+            :queue => "%s_collective" % cluster_name
+          }
+        end
+
+        # Processor specific process logic
+        #
+        # This received a message from the Federation and converts it into a message that will be
+        # published to the collective, stores the outgoing message in the outbox queue
+        #
+        # @param (see Base#process)
+        def process(msg)
+          headers = msg["headers"]
+          raise("Collective received an invalid message, cannot process: %s" % [msg]) unless headers
+
+          federation = headers["federation"]
+          raise("Collective received an unfederated message, cannot process: %s" % [msg["headers"]]) unless federation
+
+          Log.info("Collective received %s from %s" % [federation["req"], headers["mc_sender"]])
+
+          reply_to = federation.delete("reply-to")
+
+          record_seen(headers)
+
+          Log.debug("collective => federation: %s" % [headers])
+
+          @outbox << {
+            :targets => [reply_to],
+            :req => federation["req"],
+            :data => JSON.dump(msg)
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/federation_broker/federation_processor.rb
+++ b/lib/mcollective/util/federation_broker/federation_processor.rb
@@ -1,0 +1,64 @@
+require_relative "base"
+
+module MCollective
+  module Util
+    class FederationBroker
+      class FederationProcessor < Base
+        # @see Base#servers
+        def servers
+          servers = @choria.federation_middleware_servers
+
+          raise("Could not find any federation middleware servers in configuration or SRV records") unless servers
+
+          servers.map do |host, port|
+            URI("nats://%s:%s" % [host, port])
+          end.map(&:to_s)
+        end
+
+        # @see Base#processor_type
+        def processor_type
+          "federation"
+        end
+
+        # @see Base#queue
+        def queue
+          {
+            :name => federation_source_name,
+            :queue => "%s_federation" % cluster_name
+          }
+        end
+
+        # Processor specific process logic
+        #
+        # This received a message from the Collective and converts it into a message that will be
+        # published to the Federation, stores the outgoing message in the outbox queue
+        #
+        # @param (see Base#process)
+        def process(msg)
+          headers = msg["headers"]
+
+          raise("Received an invalid message, cannot process: %s" % [msg.inspect]) unless headers
+
+          federation = headers["federation"]
+
+          raise("Received an unfederated message, cannot process: %s" % [msg["headers"].inspect]) unless federation
+
+          Log.info("Federation received %s from %s" % [federation["req"], headers["mc_sender"]])
+
+          federation["reply-to"] = headers.delete("reply-to")
+          headers["reply-to"] = collective_source_name
+
+          record_seen(headers)
+
+          Log.debug("federation => collective: %s" % [headers])
+
+          @outbox << {
+            :targets => federation.delete("target"),
+            :req => federation["req"],
+            :data => JSON.dump(msg)
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/federation_broker/stats.rb
+++ b/lib/mcollective/util/federation_broker/stats.rb
@@ -1,0 +1,136 @@
+require "webrick/httpserver"
+
+module MCollective
+  module Util
+    class FederationBroker
+      class Stats
+        # @param broker [FederationBroker]
+        def initialize(broker)
+          @broker = broker
+          @lock = Mutex.new
+          @stats = initial_stats
+
+          start_stats_web_server if stats_port
+          start_stats_publisher
+        end
+
+        # Initial empty stats
+        #
+        # @return [Hash]
+        def initial_stats
+          {
+            "version" => Choria::VERSION,
+            "start_time" => Time.now.to_i,
+            "cluster" => @broker.cluster_name,
+            "instance" => @broker.instance_name,
+            "config_file" => Config.instance.configfile,
+            "status" => "unknown",
+            "threads" => {},
+            "collective" => {},
+            "federation" => {},
+            "/stats" => {
+              "requests" => 0
+            }
+          }
+        end
+
+        # The port used to listen on for HTTP stats requests
+        #
+        # @return [Integer,nil]
+        def stats_port
+          @broker.stats_port
+        end
+
+        # Updates the stats hash with current information from the broker
+        #
+        # @return [Hash] the updated stats
+        def update_broker_stats
+          @lock.synchronize do
+            @stats["threads"] = @broker.thread_status
+            @stats["status"] = @broker.ok? ? "OK" : "CRITICAL"
+            @stats["collective"] = @broker.processors["collective"].stats
+            @stats["federation"] = @broker.processors["federation"].stats
+
+            @stats
+          end
+        end
+
+        # Services a request for stats
+        #
+        # @param req [WEBrick::HTTPRequest]
+        # @param res [WEBrick::HTTPResponse]
+        # @return [void]
+        def serve_stats(req, res)
+          Log.info("/stats request from %s:%d" % [req.peeraddr[2], req.peeraddr[1]])
+
+          @lock.synchronize { @stats["/stats"]["requests"] += 1 }
+
+          res["Content-Type"] = "application/json"
+          res.body = JSON.pretty_generate(update_broker_stats)
+        end
+
+        def stats_target
+          "federation.%s.stats" % [@broker.cluster_name]
+        end
+
+        # Starts a thread that publishes the broker stats every 10 seconds
+        def start_stats_publisher
+          Log.info("Starting statistics publisher publishing to %s" % stats_target)
+
+          thread = Thread.new do
+            begin
+              loop do
+                sleep 10
+
+                next unless @broker.started?
+
+                @broker.connections["federation"].publish(stats_target, update_broker_stats.to_json)
+              end
+            rescue
+              Log.error("Failed to publish stats to federation %s: %s: %s" % [stats_target, $!.class, $!.to_s])
+              Log.debug($!.backtrace.join("\n\t"))
+
+              retry
+            end
+          end
+
+          @broker.record_thread("stats_publisher", thread)
+        end
+
+        # Starts a Webrick server serving stats requests
+        #
+        # @note when there is no stats_port configured this will do nothing
+        # @return [void]
+        def start_stats_web_server
+          return unless stats_port
+
+          thread = Thread.new do
+            begin
+              Log.info("Listening for stats requests on localhost:%d/stats" % [stats_port])
+
+              server = WEBrick::HTTPServer.new(
+                :Port => stats_port,
+                :BindAddress => "127.0.0.1",
+                :Logger => Log,
+                :ServerSoftware => "Choria Federation Broker %s" % [Choria::VERSION],
+                :AccessLog => []
+              )
+
+              server.mount_proc("/stats") {|req, res| serve_stats(req, res) }
+
+              server.start unless ENV["TRAVIS"]
+            rescue
+              Log.error("Could not start stats server: %s: %s" % [$!.class, $!.to_s])
+              Log.debug($!.backtrace.join("\n\t"))
+              sleep 1
+
+              retry
+            end
+          end
+
+          @broker.record_thread("stats_web_server", thread)
+        end
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/natswrapper.rb
+++ b/lib/mcollective/util/natswrapper.rb
@@ -119,7 +119,7 @@ module MCollective
 
       # Starts the EM based NATS connection
       #
-      # @param options [Hash] Options as per {#NATS.start}
+      # @param options [Hash] Options as per {#NATS::IO::Client#connect}
       def start(options={})
         # Client connects pretty much soon as it's initialized which is very early
         # and some applications like 'request_cert' just doesnt need/want a client
@@ -128,7 +128,7 @@ module MCollective
         return if @force_Stop
 
         @client.on_reconnect do
-          Log.warn("Reconnected after connection failure: %s" % @client.connected_server)
+          Log.warn("Reconnected after connection failure: %s" % connected_server)
           log_nats_pool
           @backoffcount = 1
         end
@@ -204,12 +204,13 @@ module MCollective
       # Subscribes to a message source
       #
       # @param source_name [String]
-      def subscribe(source_name)
+      # @param options [Hash] options as accepted by {NATS::IO::Client#subscribe}
+      def subscribe(source_name, options={})
         @subscription_mutex.synchronize do
           Log.debug("Subscribing to %s" % source_name)
 
           unless @subscriptions.include?(source_name)
-            @subscriptions[source_name] = @client.subscribe(source_name) do |msg, _, sub|
+            @subscriptions[source_name] = @client.subscribe(source_name, options) do |msg, _, sub|
               Log.debug("Received a message on %s" % [sub])
               @received_queue << msg
             end

--- a/lib/mcollective/util/playbook/data_stores/base.rb
+++ b/lib/mcollective/util/playbook/data_stores/base.rb
@@ -42,7 +42,7 @@ module MCollective
           #
           # @note when the lock does not exist it should not raise an error
           # @param key [String] the lock name
-          # @raize [StandardError] when releaging fails
+          # @raise [StandardError] when releaging fails
           def release(key)
             raise(NotImplementedError, "release not implemented in %s" % [self.class], caller)
           end

--- a/module/data/plugin.yaml
+++ b/module/data/plugin.yaml
@@ -15,6 +15,7 @@ mcollective_choria::server_files:
 mcollective_choria::client_files:
  - application/choria.rb
  - application/playbook.rb
+ - application/federation.rb
  - discovery/choria.ddl
  - discovery/choria.rb
  - util/playbook/data_stores/base.rb
@@ -48,12 +49,18 @@ mcollective_choria::client_files:
  - util/playbook/uses.rb
 mcollective_choria::common_directories:
  - util/choria
+ - util/choria/federation_broker
 mcollective_choria::common_files:
  - agent/choria_util.ddl
  - connector/nats.ddl
  - connector/nats.rb
  - security/choria.rb
  - util/choria/orchestrator.rb
+ - util/choria/federation_broker.rb
+ - util/choria/federation_broker/base.rb
+ - util/choria/federation_broker/collective_processor.rb
+ - util/choria/federation_broker/federation_processor.rb
+ - util/choria/federation_broker/stats.rb
  - util/choria/puppet_v3_environment.rb
  - util/choria.rb
  - util/natswrapper.rb

--- a/spec/unit/mcollective/connector/nats_spec.rb
+++ b/spec/unit/mcollective/connector/nats_spec.rb
@@ -407,7 +407,7 @@ module MCollective
       end
 
       it "should support recording the route" do
-        connector.stubs(:get_option).with("nats.record_route", "n").returns("y")
+        choria.stubs(:record_nats_route?).returns(true)
         connector.stubs(:connected_server).returns("nats.example")
         connection.expects(:receive).returns({"data" => "rspec", "headers" => {}}.to_json)
         result = connector.receive

--- a/spec/unit/mcollective/util/federation_broker/base_spec.rb
+++ b/spec/unit/mcollective/util/federation_broker/base_spec.rb
@@ -1,0 +1,105 @@
+require "spec_helper"
+require "mcollective/util/federation_broker"
+
+module MCollective
+  module Util
+    class FederationBroker
+      describe Base do
+        let(:fb) { stub(:cluster_name => "rspec", :instance_name => "a") }
+        let(:inbox) { stub }
+        let(:outbox) { stub }
+        let(:nats) { stub(:connected_server => "rspec.local") }
+        let(:base) { Base.new(fb, inbox, outbox) }
+
+        before(:each) do
+          NatsWrapper.expects(:new).returns(nats)
+          base.stubs(:processor_type).returns("rspec_processor")
+          base.stubs(:queue).returns(
+            :name => "rspec.target",
+            :queue => "rspec"
+          )
+        end
+
+        describe "#consume" do
+          it "should consume from the queue and process messages" do
+            base.expects(:consume_from).with(base.queue).yields(JSON.dump("x" => "y"))
+            base.expects(:process).with("x" => "y")
+            base.consume
+          end
+        end
+
+        describe "#start_connection_and_handlers" do
+          it "should start the connection, handler and consumer" do
+            base.stubs(:servers).returns(["nats://1.example"])
+            base.choria.stubs(:ssl_context).returns(:ssl => :context)
+            base.connection.expects(:start).with(
+              :max_reconnect_attempts => -1,
+              :reconnect_time_wait => 1,
+              :name => "fedbroker_rspec_a",
+              :servers => ["nats://1.example"],
+              :tls => {
+                :context => {:ssl => :context}
+              }
+            )
+            base.expects(:inbox_handler)
+            base.expects(:consume)
+            base.start_connection_and_handlers
+          end
+        end
+
+        describe "#handle_inbox_item" do
+          it "should publish all targets" do
+            base.connection.expects(:publish).with("target.1", "x")
+            base.connection.expects(:publish).with("target.2", "x")
+            base.handle_inbox_item(:targets => ["target.1", "target.2"], :data => "x")
+          end
+        end
+
+        describe "#record_seen" do
+          it "should add the normal seen headers" do
+            headers = {"seen-by" => ["x"]}
+            base.record_seen(headers)
+            expect(headers["seen-by"]).to eq(["x", "fedbroker_rspec_a"])
+          end
+
+          it "should support recording the route" do
+            base.choria.expects(:record_nats_route?).returns(true)
+            base.record_seen(headers = {})
+            expect(headers["seen-by"]).to eq(["rspec.local", "fedbroker_rspec_a"])
+          end
+        end
+
+        describe "#stats" do
+          it "should report the right stats" do
+            base.stubs(:queue).returns(
+              :name => "rspec.target",
+              :queue => "rspec"
+            )
+
+            inbox.expects(:size).returns(10)
+            expect(base.stats).to eq(
+              "connected_server" => "rspec.local",
+              "last_message" => 0,
+              "work_queue" => 10,
+              "sent" => 0,
+              "received" => 0,
+              "source" => "rspec.target"
+            )
+          end
+        end
+
+        describe "#federation_source_name" do
+          it "should create the right data" do
+            expect(base.federation_source_name).to eq("choria.federation.rspec.federation")
+          end
+        end
+
+        describe "#collective_source_name" do
+          it "should create the right data" do
+            expect(base.collective_source_name).to eq("choria.federation.rspec.collective")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/util/federation_broker/collective_processor_spec.rb
+++ b/spec/unit/mcollective/util/federation_broker/collective_processor_spec.rb
@@ -1,0 +1,70 @@
+require "spec_helper"
+require "mcollective/util/federation_broker"
+
+module MCollective
+  module Util
+    class FederationBroker
+      describe CollectiveProcessor do
+        let(:fb) { stub(:cluster_name => "rspec", :instance_name => "a") }
+        let(:inbox) { stub }
+        let(:outbox) { stub }
+        let(:nats) { stub(:connected_server => "rspec.local") }
+        let(:cp) { CollectiveProcessor.new(fb, inbox, outbox) }
+
+        describe "#process" do
+          it "should add the correct message to the outbox" do
+            msg = {
+              "body" => "body",
+              "headers" => {
+                "federation" => {
+                  "req" => "rspecreq",
+                  "reply-to" => "x.y.z"
+                }
+              }
+            }
+
+            JSON.expects(:dump).with(
+              "body" => "body",
+              "headers" => {
+                "seen-by" => ["fedbroker_rspec_a"],
+                "federation" => {
+                  "req" => "rspecreq"
+                }
+              }
+            ).returns("dumped_json")
+
+            outbox.expects(:<<).with(
+              :targets => ["x.y.z"],
+              :req => "rspecreq",
+              :data => "dumped_json"
+            )
+
+            cp.process(msg)
+          end
+        end
+
+        describe "#queue" do
+          it "should be correct" do
+            expect(cp.queue).to eq(
+              :name => "choria.federation.rspec.collective",
+              :queue => "rspec_collective"
+            )
+          end
+        end
+
+        describe "#processor_type" do
+          it "should be collective" do
+            expect(cp.processor_type).to eq("collective")
+          end
+        end
+
+        describe "#servers" do
+          it "should get choria middleware servers" do
+            cp.choria.stubs(:middleware_servers).with("puppet", "4222").returns([["rspec1", "4222"], ["rspec2", "4223"]])
+            expect(cp.servers).to eq(["nats://rspec1:4222", "nats://rspec2:4223"])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/util/federation_broker/federation_processor_spec.rb
+++ b/spec/unit/mcollective/util/federation_broker/federation_processor_spec.rb
@@ -1,0 +1,73 @@
+require "spec_helper"
+require "mcollective/util/federation_broker"
+
+module MCollective
+  module Util
+    class FederationBroker
+      describe FederationProcessor do
+        let(:fb) { stub(:cluster_name => "rspec", :instance_name => "a") }
+        let(:inbox) { stub }
+        let(:outbox) { stub }
+        let(:nats) { stub(:connected_server => "rspec.local") }
+        let(:fp) { FederationProcessor.new(fb, inbox, outbox) }
+
+        describe "#process" do
+          it "should add the correct message to the outbox" do
+            msg = {
+              "body" => "body",
+              "headers" => {
+                "reply-to" => "x.y.z",
+                "federation" => {
+                  "target" => ["broadcast.discovery.agent"],
+                  "req" => "rspecreq"
+                }
+              }
+            }
+
+            JSON.expects(:dump).with(
+              "body" => "body",
+              "headers" => {
+                "federation" => {
+                  "req" => "rspecreq",
+                  "reply-to" => "x.y.z"
+                },
+                "reply-to" => "choria.federation.rspec.collective",
+                "seen-by" => ["fedbroker_rspec_a"]
+              }
+            ).returns("dumped_json")
+
+            outbox.expects(:<<).with(
+              :targets => ["broadcast.discovery.agent"],
+              :req => "rspecreq",
+              :data => "dumped_json"
+            )
+
+            fp.process(msg)
+          end
+        end
+
+        describe "#queue" do
+          it "should be correct" do
+            expect(fp.queue).to eq(
+              :name => "choria.federation.rspec.federation",
+              :queue => "rspec_federation"
+            )
+          end
+        end
+
+        describe "#processor_type" do
+          it "should be collective" do
+            expect(fp.processor_type).to eq("federation")
+          end
+        end
+
+        describe "#servers" do
+          it "should get choria middleware servers" do
+            fp.choria.stubs(:federation_middleware_servers).returns([["rspec1", "4222"], ["rspec2", "4223"]])
+            expect(fp.servers).to eq(["nats://rspec1:4222", "nats://rspec2:4223"])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/util/federation_broker/stats_spec.rb
+++ b/spec/unit/mcollective/util/federation_broker/stats_spec.rb
@@ -1,0 +1,71 @@
+require "spec_helper"
+require "mcollective/util/federation_broker"
+
+module MCollective
+  module Util
+    class FederationBroker
+      describe Stats do
+        let(:fb) { FederationBroker.new("rspec", "test") }
+        let(:stats) { fb.stats }
+
+        describe "#serve_stats" do
+          it "should serve the right stats" do
+            res = stub
+            req = stub(:peeraddr => ["AF_INET", 80, "localhost", "127.0.0.1"])
+
+            res.expects(:[]=).with("Content-Type", "application/json")
+            stats.expects(:update_broker_stats).returns("rspec" => "stub")
+            res.expects(:body=).with(JSON.pretty_generate("rspec" => "stub"))
+
+            stats.serve_stats(req, res)
+          end
+        end
+
+        describe "#update_broker_stats" do
+          it "should fetch the right data" do
+            fb.expects(:thread_status).returns("rspec" => {"alive" => true})
+            fb.expects(:ok?).returns(true)
+            fb.expects(:processors).returns(
+              "collective" => stub(:stats => cs = stub),
+              "federation" => stub(:stats => fs = stub)
+            ).twice
+
+            expect(stats.update_broker_stats).to include(
+              "status" => "OK",
+              "collective" => cs,
+              "federation" => fs,
+              "threads" => {
+                "rspec" => {
+                  "alive" => true
+                }
+              }
+            )
+          end
+        end
+
+        describe "#initial_stats" do
+          it "should create the correct structure" do
+            t = Time.now
+            Time.stubs(:now).returns(t)
+            Config.instance.stubs(:configfile).returns("/nonexisting")
+
+            expect(stats.initial_stats).to eq(
+              "version" => Choria::VERSION,
+              "start_time" => t.to_i,
+              "cluster" => "rspec",
+              "instance" => "test",
+              "config_file" => "/nonexisting",
+              "status" => "unknown",
+              "collective" => {},
+              "federation" => {},
+              "threads" => {},
+              "/stats" => {
+                "requests" => 0
+              }
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/util/federation_broker_spec.rb
+++ b/spec/unit/mcollective/util/federation_broker_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+require "mcollective/util/federation_broker"
+
+module MCollective
+  module Util
+    describe FederationBroker do
+      let(:fb) { FederationBroker.new("rspec", "test") }
+
+      describe "#stats_port" do
+        it "should accept a given port" do
+          fb.choria.expects(:stats_port).never
+          expect(FederationBroker.new("rspec", "test", 1235).stats_port).to eq(1235)
+        end
+
+        it "should consult choria" do
+          fb.choria.expects(:stats_port).returns(1234)
+          expect(fb.stats_port).to be(1234)
+        end
+      end
+
+      describe "#record_thread" do
+        it "should record the thread by name" do
+          expect(fb.threads).to_not include("rspec")
+          fb.record_thread("rspec", t = Thread.new {})
+          expect(fb.threads["rspec"]).to be(t)
+          expect(fb.threads["rspec"]["_name"]).to eq("rspec")
+        end
+
+        it "should fail for dup thread names" do
+          fb.record_thread("rspec", Thread.new {})
+          expect { fb.record_thread("rspec", stub) }.to raise_error("Thread called 'rspec' already exist in the thread registry")
+        end
+      end
+
+      describe "#ok?" do
+        it "should be success if all alive" do
+          t = Thread.new { sleep 10 }
+          fb.record_thread("rspec", t)
+          expect(fb.ok?).to be(true)
+        end
+
+        it "should not be ok when not all are alive" do
+          t = Thread.new { raise }
+          Thread.kill(t)
+
+          10.times { Thread.pass }
+
+          fb.record_thread("rspec", t)
+          expect(fb.ok?).to be(false)
+        end
+      end
+
+      describe "#thread_status" do
+        it "should include all recorded threads" do
+          fb.record_thread("rspec", Thread.new { sleep 1})
+          expect(fb.thread_status).to include(
+            "rspec" => {"alive" => true, "status" => "run"}
+          )
+        end
+      end
+
+      describe "#start" do
+        it "should start and store all threads and set it started" do
+          FederationBroker::CollectiveProcessor.expects(:new).with(fb, instance_of(Queue), instance_of(Queue)).returns(cp = stub)
+          FederationBroker::FederationProcessor.expects(:new).with(fb, instance_of(Queue), instance_of(Queue)).returns(fp = stub)
+
+          cp.expects(:start).returns(cc = stub)
+          fp.expects(:start).returns(fc = stub)
+
+          expect(fb.started?).to be(false)
+          fb.start
+          expect(fb.started?).to be(true)
+
+          expect(fb.connections["collective"]).to be(cc)
+          expect(fb.connections["federation"]).to be(fc)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/util/natswrapper_spec.rb
+++ b/spec/unit/mcollective/util/natswrapper_spec.rb
@@ -86,12 +86,17 @@ module MCollective
 
     describe "#subscribe" do
       it "should subscribe only once" do
-        client.stubs(:subscribe).yields("msg", "x", "sub").returns(1).once
+        client.stubs(:subscribe).with("rspec.dest", {}).yields("msg", "x", "sub").returns(1).once
 
         wrapper.subscribe("rspec.dest")
         expect(wrapper.subscriptions).to have_key("rspec.dest")
         wrapper.subscribe("rspec.dest")
         expect(wrapper.receive).to eq("msg")
+      end
+
+      it "should support options" do
+        client.expects(:subscribe).with("x", :queue => "y").returns(1)
+        wrapper.subscribe("x", :queue => "y")
       end
     end
 


### PR DESCRIPTION
This adds a `mco federation` command that can run a federation broker
instance observe running federation broker clusters