### PR TITLE
(#228) Validate messages received by the Federation Broker

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require "rspec/core/rake_task"
 
+ENV["CHORIA_RAKE"] = $$.to_s
+
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = "--profile" if ENV["TRAVIS"] == "true"
 end

--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -1,6 +1,5 @@
 require_relative "choria/puppet_v3_environment"
 require_relative "choria/orchestrator"
-require_relative "federation_broker"
 
 require "net/http"
 require "resolv"
@@ -21,6 +20,21 @@ module MCollective
         @config = Config.instance
 
         check_ssl_setup if check_ssl
+      end
+
+      # Factory for Federation Brokers
+      #
+      # We do it here to avoid always requiring all the federation broker code
+      # when its not needed
+      #
+      # @param cluster_name [String] the name of the federation broker cluster
+      # @param instance_name [String, nil] the name of this specific instance in the cluster
+      # @param stats_port [Integer] the port to listen to for stats, uses choria.stats_port when nil
+      # @return [FederationBroker]
+      def federation_broker(cluster_name, instance_name, stats_port)
+        require_relative "federation_broker"
+
+        FederationBroker.new(cluster_name, instance_name, stats_port)
       end
 
       # Which port to provide stats over HTTP on

--- a/lib/mcollective/util/federation_broker.rb
+++ b/lib/mcollective/util/federation_broker.rb
@@ -91,7 +91,7 @@ module MCollective
       # Connect to the federation and observes published stats
       #
       # This will yield a hash of stats for every instance in the
-      # Federation Broker in {@cluster_name}
+      # Federation Broker in {cluster_name}
       def observe_stats
         ENV["CHORIA_FED_COLLECTIVE"] = @cluster_name
 

--- a/lib/mcollective/util/federation_broker/base.rb
+++ b/lib/mcollective/util/federation_broker/base.rb
@@ -60,9 +60,22 @@ module MCollective
 
         # Processor specific process logic
         #
+        # @abstract
         # @param msg [Hash] message from the wire
         def process(msg)
           raise(NotImplementedError, "%s does not implement the #process method" % [self.class])
+        end
+
+        # Determines if a message should be processed
+        #
+        # This should do validity checks, structure tests, security checks against the reply-to etc
+        #
+        # @abstract
+        # @param msg [Hash] the message to test
+        # @return [Boolean]
+        def should_process?(msg)
+          Log.warn("%s did not override should_process?, denying all messages" % [self.class])
+          false
         end
 
         # Processor statistics
@@ -241,7 +254,7 @@ module MCollective
             local_stats["received"] += 1
             local_stats["last_message"] = Time.now.to_i
 
-            process(msg)
+            process(msg) if should_process?(msg)
           end
         end
 

--- a/lib/mcollective/util/federation_broker/federation_processor.rb
+++ b/lib/mcollective/util/federation_broker/federation_processor.rb
@@ -28,6 +28,49 @@ module MCollective
           }
         end
 
+        # @see Base#should_process?
+        def should_process?(msg)
+          unless msg.is_a?(Hash)
+            Log.warn("Received a non hash message, cannot process: %s" % [msg.inspect])
+            return false
+          end
+
+          unless headers = msg["headers"]
+            Log.warn("Received a message without headers, cannot process: %s" % [msg.inspect])
+            return false
+          end
+
+          unless federation = headers["federation"]
+            Log.warn("Received an unfederated message, cannot process: %s" % [msg.inspect])
+            return false
+          end
+
+          reply_to = headers["reply-to"]
+
+          unless reply_to.is_a?(String)
+            Log.warn("Received an invalid reply to header:, cannot process: %s" % [msg.inspect])
+            return false
+          end
+
+          # All reply-to should match NATS topics actually used to receive replies from agents or nodes else someone
+          # might abuse this to bridge into other collectives or federations see {Connector::Nats#make_target}
+          unless reply_to =~ /^.+?\.reply\./
+            Log.warn("Received an invalid reply to target '%s', cannot process: %s" % [reply_to, msg.inspect])
+            return false
+          end
+
+          # All targets should match NATS topics actually used to talk to agents or nodes else someone
+          # might abuse this to bridge into other collectives or federations see {Connector::Nats#make_target}
+          federation["target"].each do |target|
+            unless target =~ /^.+?\.((broadcast\.agent)|(node))\./
+              Log.warn("Received an unexpected remote target '%s', cannot process: %s" % [target, msg.inspect])
+              return false
+            end
+          end
+
+          true
+        end
+
         # Processor specific process logic
         #
         # This received a message from the Collective and converts it into a message that will be
@@ -36,12 +79,7 @@ module MCollective
         # @param (see Base#process)
         def process(msg)
           headers = msg["headers"]
-
-          raise("Received an invalid message, cannot process: %s" % [msg.inspect]) unless headers
-
           federation = headers["federation"]
-
-          raise("Received an unfederated message, cannot process: %s" % [msg["headers"].inspect]) unless federation
 
           Log.info("Federation received %s from %s" % [federation["req"], headers["mc_sender"]])
 

--- a/lib/mcollective/util/federation_broker/stats.rb
+++ b/lib/mcollective/util/federation_broker/stats.rb
@@ -70,7 +70,7 @@ module MCollective
         end
 
         def stats_target
-          "federation.%s.stats" % [@broker.cluster_name]
+          "choria.federation.%s.stats" % [@broker.cluster_name]
         end
 
         # Starts a thread that publishes the broker stats every 10 seconds
@@ -118,7 +118,7 @@ module MCollective
 
               server.mount_proc("/stats") {|req, res| serve_stats(req, res) }
 
-              server.start unless ENV["TRAVIS"]
+              server.start unless ENV["CHORIA_RAKE"]
             rescue
               Log.error("Could not start stats server: %s: %s" % [$!.class, $!.to_s])
               Log.debug($!.backtrace.join("\n\t"))

--- a/module/data/plugin.yaml
+++ b/module/data/plugin.yaml
@@ -49,18 +49,18 @@ mcollective_choria::client_files:
  - util/playbook/uses.rb
 mcollective_choria::common_directories:
  - util/choria
- - util/choria/federation_broker
+ - util/federation_broker
 mcollective_choria::common_files:
  - agent/choria_util.ddl
  - connector/nats.ddl
  - connector/nats.rb
  - security/choria.rb
  - util/choria/orchestrator.rb
- - util/choria/federation_broker.rb
- - util/choria/federation_broker/base.rb
- - util/choria/federation_broker/collective_processor.rb
- - util/choria/federation_broker/federation_processor.rb
- - util/choria/federation_broker/stats.rb
+ - util/federation_broker.rb
+ - util/federation_broker/base.rb
+ - util/federation_broker/collective_processor.rb
+ - util/federation_broker/federation_processor.rb
+ - util/federation_broker/stats.rb
  - util/choria/puppet_v3_environment.rb
  - util/choria.rb
  - util/natswrapper.rb

--- a/spec/unit/mcollective/util/federation_broker/base_spec.rb
+++ b/spec/unit/mcollective/util/federation_broker/base_spec.rb
@@ -23,7 +23,15 @@ module MCollective
         describe "#consume" do
           it "should consume from the queue and process messages" do
             base.expects(:consume_from).with(base.queue).yields(JSON.dump("x" => "y"))
+            base.expects(:should_process?).with("x" => "y").returns(true)
             base.expects(:process).with("x" => "y")
+            base.consume
+          end
+
+          it "should not process message that do not validate" do
+            base.expects(:consume_from).with(base.queue).yields(JSON.dump("x" => "y"))
+            base.expects(:should_process?).with("x" => "y").returns(false)
+            base.expects(:process).never
             base.consume
           end
         end

--- a/spec/unit/mcollective/util/federation_broker_spec.rb
+++ b/spec/unit/mcollective/util/federation_broker_spec.rb
@@ -34,18 +34,12 @@ module MCollective
 
       describe "#ok?" do
         it "should be success if all alive" do
-          t = Thread.new { sleep 10 }
-          fb.record_thread("rspec", t)
+          fb.record_thread("rspec", stub(:alive? => true, :[]= => nil))
           expect(fb.ok?).to be(true)
         end
 
         it "should not be ok when not all are alive" do
-          t = Thread.new { raise }
-          Thread.kill(t)
-
-          10.times { Thread.pass }
-
-          fb.record_thread("rspec", t)
+          fb.record_thread("rspec", stub(:alive? => false, :[]= => nil))
           expect(fb.ok?).to be(false)
         end
       end


### PR DESCRIPTION
This validates that messages received on the Federation are things the
federation side would send.  Ie. they are not attempting to set targets
to other Federation Brokers or similar sneaky thing to attempt to hop
across Federations

It also validates the Collective side to ensure someone there is not
attempting to hop to other Collectives or Federations by forging
messages

Also fixes the paths to the files in the module