### PR TITLE
(#228) Add Puppet bits to configure Federation Brokers

### DIFF
--- a/lib/mcollective/application/federation.rb
+++ b/lib/mcollective/application/federation.rb
@@ -32,7 +32,7 @@ EOU
 
       def broker_command
         configuration[:cluster] = Config.instance.pluginconf["choria.federation.cluster"] unless configuration[:cluster]
-        configuration[:instance] = Config.instance.pluginconfig["choria.federation.instance"] unless configuration[:instance]
+        configuration[:instance] = Config.instance.pluginconf["choria.federation.instance"] unless configuration[:instance]
 
         abort("A cluster name is required, use --cluster or plugin.choria.federation.cluster") unless configuration[:cluster]
 

--- a/lib/mcollective/connector/nats.rb
+++ b/lib/mcollective/connector/nats.rb
@@ -107,7 +107,7 @@ module MCollective
           "mc_sender" => @config.identity
         }
 
-        if Util.str_to_bool(get_option("nats.record_route", "n"))
+        if Util.str_to_bool(get_option("choria.record_route", "n"))
           headers["seen-by"] = [connected_server]
         end
 

--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -399,7 +399,7 @@ module MCollective
       #
       # @return [Boolean]
       def record_nats_route?
-        Util.str_to_bool(get_option("nats.record_route", "n"))
+        Util.str_to_bool(get_option("choria.record_route", "n"))
       end
 
       # Determines if servers should be randomized

--- a/module/files/federation_broker.service
+++ b/module/files/federation_broker.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Choria.io Federation Broker
+After=network.target
+
+[Service]
+StandardOutput=syslog
+StandardError=syslog
+ExecStart=/opt/puppetlabs/bin/mco federation broker --config /etc/puppetlabs/mcollective/federation/%i.cfg
+
+[Install]
+WantedBy=multi-user.target

--- a/module/manifests/federation_broker.pp
+++ b/module/manifests/federation_broker.pp
@@ -1,0 +1,66 @@
+define mcollective_choria::federation_broker (
+  Integer $instances = 1,
+  Integer $stats_base_port = 0,
+  Array[String] $federation_middleware_hosts = [],
+  Array[String] $collective_middleware_hosts = [],
+  String $srv_domain = $facts["networking"]["domain"],
+  Boolean $record_route = false,
+  Boolean $randomize_middleware_hosts = false,
+  Enum["debug", "info", "warn"] $log_level = "info",
+  Enum["present", "absent"] $ensure = "present"
+) {
+  range(1, $instances).each |$instance| {
+    $config_file = "${mcollective::configdir}/federation/${name}_${instance}.cfg"
+    $log_file = "/var/log/puppetlabs/mcollective-federation_${name}_${instance}.log"
+
+    if $stats_base_port == 0 {
+      $stats_port = 0
+    } else {
+      $stats_port = $stats_base_port + $instance - 1
+    }
+
+    if $ensure == "present" {
+      $config = epp("mcollective_choria/federation_config.epp", {
+        "cluster"                     => $name,
+        "instance"                    => $instance,
+        "stats_port"                  => $stats_port,
+        "federation_middleware_hosts" => $federation_middleware_hosts,
+        "collective_middleware_hosts" => $collective_middleware_hosts,
+        "srv_domain"                  => $srv_domain,
+        "log_file"                    => $log_file,
+        "log_level"                   => $log_level,
+        "record_route"                => $record_route,
+        "randomize_middleware_hosts"  => $randomize_middleware_hosts
+      })
+
+      mcollective::config_file{$config_file:
+        owner   => $mcollective::plugin_owner,
+        group   => $mcollective::plugin_group,
+        mode    => $mcollective::plugin_mode,
+        content => $config,
+        notify  => Service["federation_broker@${name}_${instance}"]
+      } ->
+
+      systemd::unit_file{"federation_broker@${name}_${instance}.service":
+        source => "puppet:///modules/mcollective_choria/federation_broker.service"
+      } ->
+
+      service{"federation_broker@${name}_${instance}":
+        enable => true,
+        ensure => running
+      }
+    } else {
+      service{"federation_broker@${name}_${instance}":
+        ensure => "stopped"
+      } ->
+
+      systemd::unit_file{"federation_broker@${name}_${instance}.service":
+        ensure => "absent"
+      } ->
+
+      mcollective::config_file{$config_file:
+        ensure => "absent"
+      }
+    }
+  }
+}

--- a/module/metadata.json
+++ b/module/metadata.json
@@ -8,13 +8,14 @@
   "project_page": "https://github.com/choria-io/mcollective-choria/wiki",
   "issues_url": "https://github.com/choria-io/mcollective-choria/issues",
   "dependencies": [
-    { "name": "choria/mcollective","version_requirement":">= 0.0.24 < 2.0.0"},
+    { "name": "choria/mcollective","version_requirement":">= 0.0.26 < 2.0.0"},
     { "name": "choria/mcollective_agent_puppet", "version_requirement": ">= 1.12.0" },
     { "name": "choria/mcollective_agent_package", "version_requirement": ">= 4.5.0" },
     { "name": "choria/mcollective_agent_service", "version_requirement": ">= 3.1.3" },
     { "name": "choria/mcollective_agent_filemgr", "version_requirement": ">= 1.1.0" },
     { "name": "choria/mcollective_util_actionpolicy", "version_requirement": ">= 2.1.0" },
-    { "name": "choria/nats", "version_requirement": ">= 0.0.6" }
+    { "name": "choria/nats", "version_requirement": ">= 0.0.6" },
+    { "name": "camptocamp/systemd", "version_requirement": ">= 0.3.0 < 1.0.0" }
   ],
   "data_provider": "hiera"
 }

--- a/module/templates/federation_config.epp
+++ b/module/templates/federation_config.epp
@@ -1,0 +1,40 @@
+<%-
+  |
+    String $cluster,
+    Integer $instance,
+    Integer $stats_port,
+    Array[String] $federation_middleware_hosts,
+    Array[String] $collective_middleware_hosts,
+    String $srv_domain,
+    String $log_file,
+    Enum["debug", "info", "warn"] $log_level,
+    Boolean $record_route,
+    Boolean $randomize_middleware_hosts
+  |
+-%>
+libdir = /opt/puppetlabs/mcollective/plugins
+logfile = <%= $log_file %>
+loglevel = <%= $log_level %>
+
+securityprovider = choria
+connector = nats
+identity = <%= $facts["networking"]["fqdn"] %>
+
+plugin.choria.federation.cluster = <%= $cluster %>
+plugin.choria.federation.instance = <%= $instance %>
+plugin.choria.srv_domain = <%= $srv_domain %>
+<%- unless $federation_middleware_hosts.empty { -%>
+plugin.choria.federation_middleware_hosts = <%= $federation_middleware_hosts.join(", ") %>
+<%- } -%>
+<%- unless $collective_middleware_hosts.empty { -%>
+plugin.choria.middleware_hosts = <%= $collective_middleware_hosts.join(", ") %>
+<%- } -%>
+<%- if $record_route { -%>
+plugin.choria.record_route = true
+<%- } -%>
+<%- unless $stats_port == 0 { -%>
+plugin.choria.stats_port = <%= $stats_port %>
+<%- } -%>
+<%- if $randomize_middleware_hosts { -%>
+choria.randomize_middleware_hosts = true
+<%- } -%>

--- a/spec/unit/mcollective/connector/nats_spec.rb
+++ b/spec/unit/mcollective/connector/nats_spec.rb
@@ -123,7 +123,7 @@ module MCollective
       end
 
       it "should support recording the route" do
-        connector.stubs(:get_option).with("nats.record_route", "n").returns("y")
+        connector.stubs(:get_option).with("choria.record_route", "n").returns("y")
         connector.stubs(:connected_server).returns("nats1.example.net")
         expect(connector.headers_for(msg)).to eq(
           "mc_sender" => "rspec_identity",

--- a/spec/unit/mcollective/util/choria_spec.rb
+++ b/spec/unit/mcollective/util/choria_spec.rb
@@ -31,7 +31,7 @@ module MCollective
         end
 
         it "should support being set" do
-          Config.instance.stubs(:pluginconf).returns("nats.record_route" => "y")
+          Config.instance.stubs(:pluginconf).returns("choria.record_route" => "y")
           expect(choria.record_nats_route?).to be(true)
         end
       end


### PR DESCRIPTION
This add mcollective_choria::federation_broker used to install many
instances of Federation Brokers.  Only supports systemd based systems
for now

Also changes the config item nats.record_route to choria.record_route
for consistancy