### PR TITLE
(#228) Allow connections to be traced

### DIFF
--- a/lib/mcollective/application/federation.rb
+++ b/lib/mcollective/application/federation.rb
@@ -9,6 +9,7 @@ mco federation [OPTIONS] <ACTION>
 The ACTION can be one of the following:
 
    observe       - view the published Federation Broker statistics
+   trace         - trace the path to a client
    broker        - start a Federation Broker instance
 
 EOU
@@ -29,6 +30,176 @@ EOU
              :arguments => ["--stats-port PORT", "--stats"],
              :description => "HTTP port to listen to for stats",
              :type => Integer
+
+      # Publish a specially crafted 'ping' with seen-by headers
+      # embedded, this signals to the entire collective to record
+      # their route
+      def trace_node(node)
+        options[:filter] = Util.empty_filter
+
+        request = Message.new("ping", nil,
+                              :agent => "discovery",
+                              :filter => options[:filter],
+                              :collective => options[:collective],
+                              :type => :request,
+                              :headers => {"seen-by" => []},
+                              :options => options)
+
+        request.discovered_hosts = [node]
+
+        client = Client.new(options)
+        found_time = 0
+        route = []
+
+        stats = client.req(request) do |reply, message|
+          abort("Tracing requests requires MCollective 2.10.3 or newer") unless message
+
+          found_time = Time.now.to_f
+
+          unless reply[:senderid] == node
+            abort("Received a response from %s while expecting a response from %s" % [reply[:senderid], node])
+          end
+
+          route = message.headers["seen-by"]
+        end
+
+        raise("Did not receive any responses to trace request") if stats[:responses] == 0
+
+        {:route => route, :stats => stats, :response_time => (found_time - stats[:starttime]), :request => request.requestid}
+      end
+
+      def route_to(route, destination)
+        route.take_while {|hop| hop[1] != destination}
+      end
+
+      def route_back(route, destination)
+        route.reverse.take_while {|hop| hop[1] != destination}.reverse
+      end
+
+      def destination_hop(route)
+        route[route_to(route, destination).size]
+      end
+
+      def extract_federation_brokers(route, destination)
+        abort("Unexpected route size %d found" % route.size) unless route.size == 5
+
+        [route_to(route, destination).last[1], route_back(route, destination).first[1]]
+      end
+
+      def draw_cluster(left, right, direction, indent)
+        if left.last == right.first && direction == :out
+          "%s└── %s" % [" " * indent, left.last]
+        elsif left.last == right.first
+          "%s┌── %s" % [" " * indent, left.last]
+        elsif direction == :out
+          [
+            "%s└─┐ %s" % [" " * indent, left.last],
+            "%s  └ %s" % [" " * indent, right.first]
+          ].join("\n")
+        else
+          [
+            "%s  ┌ %s" % [" " * indent, left.last],
+            "%s┌─┘ %s" % [" " * indent, right.first]
+          ].join("\n")
+        end
+      end
+
+      # @todo this is aweful brute force rubbish while I dont know what I want, make some algo
+      def display_unfederated_route(route)
+        c_out, node, c_in = route
+
+        if c_out[1] == node[0] && node[2] == c_out[1] && node[0] == c_out[1]
+          puts "  Shared Middleware"
+          puts
+          puts "    %s" % Util.colorize(:cyan, c_out[0])
+          puts draw_cluster(c_out, node, :out, 7)
+          puts "           └── %s" % Util.colorize(:yellow, node[1])
+
+        elsif c_out[1] == c_in[0] && node[0] == node[2]
+          puts "  NATS Cluster with Symetrical Path"
+          puts
+          puts "    %s" % Util.colorize(:cyan, c_out[0])
+          puts draw_cluster(c_out, node, :out, 7)
+          puts "           └── %s" % Util.colorize(:yellow, node[1])
+
+        else
+          puts "  NATS Cluster with Asymmetrical Path"
+          puts
+          puts "  %s" % Util.colorize(:cyan, c_out[0])
+          puts draw_cluster(c_out, node, :out, 5)
+          puts "         ├── %s" % Util.colorize(:yellow, node[1])
+          puts draw_cluster(node, c_in, :in, 5)
+          puts "  %s" % Util.colorize(:cyan, c_in[1])
+        end
+        puts
+        puts "[%s] Client [%s] Server [%s] Middleware" % [
+          Util.colorize(:cyan, "█"), Util.colorize(:yellow, "█"), "█"
+        ]
+        puts
+      end
+
+      # @todo this is aweful brute force rubbish while I dont know what I want, make some algo
+      def display_federated_route(route)
+        c_out, fb1, node, fb2, c_in = route
+
+        puts "  %s" % Util.colorize(:bold, "Request:")
+        puts "    %s" % Util.colorize(:cyan, c_out[0])
+        puts draw_cluster(c_out, fb1, :out, 7)
+        puts "            └─ %s" % Util.colorize(:green, fb1[1])
+        puts draw_cluster(fb1, node, :out, 15)
+        puts "                    └── %s" % Util.colorize(:yellow, node[1])
+        puts
+        puts "  %s" % Util.colorize(:bold, "Reply:")
+        puts "                    ┌── %s" % Util.colorize(:yellow, node[1])
+        puts draw_cluster(node, fb2, :int, 15)
+        puts "            ┌─ %s" % Util.colorize(:green, fb2[1])
+        puts draw_cluster(fb2, c_in, :in, 7)
+        puts "    %s" % Util.colorize(:cyan, c_in[1])
+        puts
+        puts "[%s] Client [%s] Federation Broker [%s] Server [%s] Middleware" % [
+          Util.colorize(:cyan, "█"), Util.colorize(:green, "█"), Util.colorize(:yellow, "█"), "█"
+        ]
+        puts
+      end
+
+      def trace_command
+        result = trace_node(configuration[:host])
+
+        abort("No routes were reported, are your nodes running a supported version?") if result[:route].empty?
+
+        puts "Received response from %s in %.2fms for message %s" % [configuration[:host], result[:response_time] * 1000, result[:request]]
+        puts
+
+        route = result[:route]
+        puts "Reported Route:"
+        puts
+        if route.size == 5
+          display_federated_route(route)
+        elsif route.size == 3
+          display_unfederated_route(route)
+        end
+
+        puts
+
+        puts "Federation Brokers Instances:"
+        puts
+        if choria.federated?
+          extract_federation_brokers(result[:route], configuration[:host]).sort.uniq.each do |broker|
+            puts"  %s" % broker
+          end
+        else
+          puts "  Unfederated"
+        end
+        puts
+
+        puts "Known Federation Broker Clusters:"
+        puts
+        if choria.federated?
+          puts "  %s" % choria.federation_collectives.join(", ")
+        else
+          puts "  Unfederated"
+        end
+      end
 
       def broker_command
         configuration[:cluster] = Config.instance.pluginconf["choria.federation.cluster"] unless configuration[:cluster]
@@ -131,6 +302,14 @@ EOU
           configuration[:command] = ARGV.shift
         else
           abort("Please specify a command, valid commands are: %s" % valid_commands.join(", "))
+        end
+
+        if configuration[:command] == "trace"
+          if ARGV.length >= 1
+            configuration[:host] = ARGV.shift
+          else
+            abort("Please specify a host to trace, example: mco federation trace node1.prod.example.net")
+          end
         end
       end
 

--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -395,13 +395,6 @@ module MCollective
         server_resolver("choria.federation_middleware_hosts", ["_mcollective-federation_server._tcp", "_x-puppet-mcollective_federation._tcp"])
       end
 
-      # Determines if the full connectivity route should be recorded
-      #
-      # @return [Boolean]
-      def record_nats_route?
-        Util.str_to_bool(get_option("choria.record_route", "n"))
-      end
-
       # Determines if servers should be randomized
       #
       # @return [Boolean]

--- a/lib/mcollective/util/federation_broker/base.rb
+++ b/lib/mcollective/util/federation_broker/base.rb
@@ -104,18 +104,18 @@ module MCollective
 
         # Records self in the seen-by headers
         #
-        # Should the configuration to record full NATS path be set this
-        # will additionally record the connected NATS server
-        #
         # @param headers [Hash]
         def record_seen(headers)
-          headers["seen-by"] ||= []
+          return unless headers.include?("seen-by")
 
-          if choria.record_nats_route?
-            headers["seen-by"] << connection.connected_server
-          end
+          c_out = processor_type == "federation" ? "collective" : "federation"
+          c_in = processor_type
 
-          headers["seen-by"] << "fedbroker_%s_%s" % [cluster_name, instance_name]
+          (headers["seen-by"] ||= []) << [
+            @broker.connections[c_in].connected_server.to_s,
+            "%s:%s @ %s" % [cluster_name, instance_name, @config.identity],
+            @broker.connections[c_out].connected_server.to_s
+          ]
         end
 
         # Handled a specific inbox item

--- a/lib/mcollective/util/federation_broker/collective_processor.rb
+++ b/lib/mcollective/util/federation_broker/collective_processor.rb
@@ -68,6 +68,7 @@ module MCollective
           headers = msg["headers"]
           federation = headers["federation"]
           reply_to = federation.delete("reply-to")
+          headers.delete("federation")
 
           Log.info("Collective received %s from %s" % [federation["req"], headers["mc_sender"]])
 

--- a/module/manifests/federation_broker.pp
+++ b/module/manifests/federation_broker.pp
@@ -4,7 +4,6 @@ define mcollective_choria::federation_broker (
   Array[String] $federation_middleware_hosts = [],
   Array[String] $collective_middleware_hosts = [],
   String $srv_domain = $facts["networking"]["domain"],
-  Boolean $record_route = false,
   Boolean $randomize_middleware_hosts = false,
   Enum["debug", "info", "warn"] $log_level = "info",
   Enum["present", "absent"] $ensure = "present"
@@ -29,7 +28,6 @@ define mcollective_choria::federation_broker (
         "srv_domain"                  => $srv_domain,
         "log_file"                    => $log_file,
         "log_level"                   => $log_level,
-        "record_route"                => $record_route,
         "randomize_middleware_hosts"  => $randomize_middleware_hosts
       })
 

--- a/module/templates/federation_config.epp
+++ b/module/templates/federation_config.epp
@@ -8,7 +8,6 @@
     String $srv_domain,
     String $log_file,
     Enum["debug", "info", "warn"] $log_level,
-    Boolean $record_route,
     Boolean $randomize_middleware_hosts
   |
 -%>
@@ -28,9 +27,6 @@ plugin.choria.federation_middleware_hosts = <%= $federation_middleware_hosts.joi
 <%- } -%>
 <%- unless $collective_middleware_hosts.empty { -%>
 plugin.choria.middleware_hosts = <%= $collective_middleware_hosts.join(", ") %>
-<%- } -%>
-<%- if $record_route { -%>
-plugin.choria.record_route = true
 <%- } -%>
 <%- unless $stats_port == 0 { -%>
 plugin.choria.stats_port = <%= $stats_port %>

--- a/spec/unit/mcollective/util/choria_spec.rb
+++ b/spec/unit/mcollective/util/choria_spec.rb
@@ -24,18 +24,6 @@ module MCollective
         end
       end
 
-      describe "#record_nats_route?" do
-        it "should default to false" do
-          Config.instance.stubs(:pluginconf).returns({})
-          expect(choria.record_nats_route?).to be(false)
-        end
-
-        it "should support being set" do
-          Config.instance.stubs(:pluginconf).returns("choria.record_route" => "y")
-          expect(choria.record_nats_route?).to be(true)
-        end
-      end
-
       describe "#ssl_context" do
         it "should create a valid ssl context" do
           choria.stubs(:ca_path).returns("spec/fixtures/ca_crt.pem")

--- a/spec/unit/mcollective/util/federation_broker/collective_processor_spec.rb
+++ b/spec/unit/mcollective/util/federation_broker/collective_processor_spec.rb
@@ -72,12 +72,7 @@ module MCollective
 
             JSON.expects(:dump).with(
               "body" => "body",
-              "headers" => {
-                "seen-by" => ["fedbroker_rspec_a"],
-                "federation" => {
-                  "req" => "rspecreq"
-                }
-              }
+              "headers" => {}
             ).returns("dumped_json")
 
             outbox.expects(:<<).with(

--- a/spec/unit/mcollective/util/federation_broker/federation_processor_spec.rb
+++ b/spec/unit/mcollective/util/federation_broker/federation_processor_spec.rb
@@ -99,8 +99,7 @@ module MCollective
                   "req" => "rspecreq",
                   "reply-to" => "x.y.z"
                 },
-                "reply-to" => "choria.federation.rspec.collective",
-                "seen-by" => ["fedbroker_rspec_a"]
+                "reply-to" => "choria.federation.rspec.collective"
               }
             ).returns("dumped_json")
 


### PR DESCRIPTION
This removes the earlier planned record_route option and instead trace
based on the presence of the seen-by header.

Tracing is a debug aid its inconceivable that someone would reconfigure
everything to add the record_route option just to debug something, much
more likely is the case where they want to initiate a trace of a
specific request on demand.

This way the new 'mco federation trace' comand can initiate a custom
request requiring seen-by headers to be made while everything else
remains the same

As above this adds a 'mco federation trace some.node' command that will
show both Federated and Unfederated routes.

Not yet sure exactly how this output should look in the long run so the
printing part is horrific and brute force but until I know the final
desired outcome investing in writing a recursive printing alog seems a
waste of time