### PR TITLE
(#228) uniquely name fed broker instances

### DIFF
--- a/lib/mcollective/audit/choria.rb
+++ b/lib/mcollective/audit/choria.rb
@@ -9,11 +9,6 @@ module MCollective
           return
         end
 
-        unless File.writable?(logfile)
-          Log.warn("Auditing is not functional because logfile '%s' is not writable" % logfile)
-          return
-        end
-
         message = {
           "timestamp" => Time.now.utc.strftime("%Y-%m-%dT%H:%M:%S.%6N%z"),
           "request_id" => request.uniqid,
@@ -25,8 +20,12 @@ module MCollective
           "data" => request.data
         }
 
-        File.open(logfile, "a") do |f|
-          f.puts(message.to_json)
+        begin
+          File.open(logfile, "a") do |f|
+            f.puts(message.to_json)
+          end
+        rescue
+          Log.warn("Auditing is not functional because writing to logfile '%s' failed %s: %s" % [logfile, $!.class, $!.to_s])
         end
       end
     end

--- a/lib/mcollective/util/federation_broker/base.rb
+++ b/lib/mcollective/util/federation_broker/base.rb
@@ -113,7 +113,7 @@ module MCollective
 
           (headers["seen-by"] ||= []) << [
             @broker.connections[c_in].connected_server.to_s,
-            "%s:%s @ %s" % [cluster_name, instance_name, @config.identity],
+            "%s:%s" % [cluster_name, instance_name],
             @broker.connections[c_out].connected_server.to_s
           ]
         end

--- a/module/templates/federation_config.epp
+++ b/module/templates/federation_config.epp
@@ -17,10 +17,10 @@ loglevel = <%= $log_level %>
 
 securityprovider = choria
 connector = nats
-identity = <%= $facts["networking"]["fqdn"] %>
+identity = <%= $trusted["certname"] %>
 
 plugin.choria.federation.cluster = <%= $cluster %>
-plugin.choria.federation.instance = <%= $instance %>
+plugin.choria.federation.instance = <%= $instance %> @ <%= $facts["networking"]["fqdn"] %>
 plugin.choria.srv_domain = <%= $srv_domain %>
 <%- unless $federation_middleware_hosts.empty { -%>
 plugin.choria.federation_middleware_hosts = <%= $federation_middleware_hosts.join(", ") %>

--- a/spec/unit/mcollective/audit/choria_spec.rb
+++ b/spec/unit/mcollective/audit/choria_spec.rb
@@ -15,14 +15,6 @@ module MCollective
           choria.audit_request(stub, stub)
         end
 
-        it "should warn when it cant write" do
-          Config.instance.stubs(:pluginconf).returns("rpcaudit.logfile" => "/nonexisting/audit.log")
-          File.expects(:writable?).with("/nonexisting/audit.log").returns(false)
-          Log.expects(:warn).with("Auditing is not functional because logfile '/nonexisting/audit.log' is not writable")
-
-          choria.audit_request(stub, stub)
-        end
-
         it "should log the correct data" do
           msg = {
             :msgtime => 1483774088,
@@ -37,7 +29,6 @@ module MCollective
           }
 
           Config.instance.stubs(:pluginconf).returns("rpcaudit.logfile" => "/nonexisting/audit.log")
-          File.expects(:writable?).with("/nonexisting/audit.log").returns(true)
           File.expects(:open).with("/nonexisting/audit.log", "a").yields(file = StringIO.new)
           Time.expects(:now).returns(Time.at(1483774088))
 

--- a/spec/unit/mcollective/util/federation_broker/base_spec.rb
+++ b/spec/unit/mcollective/util/federation_broker/base_spec.rb
@@ -72,11 +72,11 @@ module MCollective
 
             base.expects(:processor_type).returns("collective").twice
             base.record_seen(headers = {"seen-by" => [["x", "y"]]})
-            expect(headers["seen-by"]).to eq([["x", "y"], ["c_nats1", "rspec:a @ rspec_identity", "fed_nats1"]])
+            expect(headers["seen-by"]).to eq([["x", "y"], ["c_nats1", "rspec:a", "fed_nats1"]])
 
             base.expects(:processor_type).returns("federation").twice
             base.record_seen(headers = {"seen-by" => [["x", "y"]]})
-            expect(headers["seen-by"]).to eq([["x", "y"], ["fed_nats1", "rspec:a @ rspec_identity", "c_nats1"]])
+            expect(headers["seen-by"]).to eq([["x", "y"], ["fed_nats1", "rspec:a", "c_nats1"]])
           end
         end
 


### PR DESCRIPTION
This adds the identity to the federation instance name to avoid a case
where 5 nodes combine to form a production Federation Broker and they
each have a instance "1" which would be confusing