### PR TITLE
(#250) Add http 201 to the list of accepted webhook codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/04/12|250   |Accept http code 201 as a valid return code for the webhook playbook task                                |
 |2017/03/30|212   |Add batch_sleep_time to mcollective playbook task                                                        |
 |2017/03/30|244   |Show correct PuppetDB information in `mco choria show_config`                                            |
 |2017/03/30|243   |Show the Choria version in `mco choria show_config`                                                      |

--- a/lib/mcollective/util/playbook/tasks/webhook_task.rb
+++ b/lib/mcollective/util/playbook/tasks/webhook_task.rb
@@ -80,7 +80,7 @@ module MCollective
 
             Log.debug("%s request to %s returned code %s with body: %s" % [@method, uri.to_s, resp.code, resp.body])
 
-            if resp.code == "200" || resp.code == "201"
+            if ["200", "201"].include?(resp.code)
               [true, "Successfully sent %s request to webhook %s with id %s" % [@method, @uri, @request_id], [resp.body]]
             else
               [false, "Failed to send %s request to webhook %s with id %s: %s: %s" % [@method, @uri, @request_id, resp.code, resp.body], [resp.body]]

--- a/lib/mcollective/util/playbook/tasks/webhook_task.rb
+++ b/lib/mcollective/util/playbook/tasks/webhook_task.rb
@@ -80,7 +80,7 @@ module MCollective
 
             Log.debug("%s request to %s returned code %s with body: %s" % [@method, uri.to_s, resp.code, resp.body])
 
-            if resp.code == "200" || "201"
+            if resp.code == "200" || resp.code == "201"
               [true, "Successfully sent %s request to webhook %s with id %s" % [@method, @uri, @request_id], [resp.body]]
             else
               [false, "Failed to send %s request to webhook %s with id %s: %s: %s" % [@method, @uri, @request_id, resp.code, resp.body], [resp.body]]

--- a/lib/mcollective/util/playbook/tasks/webhook_task.rb
+++ b/lib/mcollective/util/playbook/tasks/webhook_task.rb
@@ -80,7 +80,7 @@ module MCollective
 
             Log.debug("%s request to %s returned code %s with body: %s" % [@method, uri.to_s, resp.code, resp.body])
 
-            if resp.code == "200"
+            if resp.code == "200" || "201"
               [true, "Successfully sent %s request to webhook %s with id %s" % [@method, @uri, @request_id], [resp.body]]
             else
               [false, "Failed to send %s request to webhook %s with id %s: %s: %s" % [@method, @uri, @request_id, resp.code, resp.body], [resp.body]]

--- a/spec/unit/mcollective/util/playbook/tasks/webhook_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/webhook_task_spec.rb
@@ -35,6 +35,20 @@ module MCollective
               )
             end
 
+            it "should handle 201 as success" do
+              task.expects(:choria).returns(choria = stub)
+              choria.expects(:https).with(:target => "localhost", :port => 80).returns(http = stub)
+              http.expects(:use_ssl=).with(false)
+              http.expects(:request).returns(stub(:code => "201", :body => "ok"))
+              expect(task.run).to eq(
+                [
+                  true,
+                  "Successfully sent POST request to webhook http://localhost/rspec?foo=bar with id 479d1982-120a-5ba8-8664-1f16a6504371",
+                  ["ok"]
+                ]
+              )
+            end
+
             it "should handle !200 as failure" do
               task.expects(:choria).returns(choria = stub)
               choria.expects(:https).with(:target => "localhost", :port => 80).returns(http = stub)


### PR DESCRIPTION
Allow the webhook to accept `201` as a "successful" http code to allow interaction with API features within tools, such as JIRA, where a user may want to create a "resource", like a comment.