### PR TITLE
(#254) do more tests in check_ssl_setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/04/18|254   |Improve sanity checks done when validating the overall SSL setup                                         |
 |2017/04/12|248   |Allow cert validation to be disabled in webhook                                                          |
 |2017/04/12|250   |Accept http code 201 as a valid return code for the webhook playbook task                                |
 |2017/03/30|212   |Add batch_sleep_time to mcollective playbook task                                                        |


### PR DESCRIPTION
Previously check_ssl_setup just checked if the ssl files existed now it
will also check if the certname in the pubcert matches what is
configured and if the pubcert was signed by the CA