### PR TITLE
(#265) Correctly use choria.puppetca_port config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/05/08|265   |Consult `choria.puppetca_port` configuration when resolving the CA                                       |
 |2017/05/04|152   |Add a etcd data store                                                                                    |
 |2017/04/19|258   |Show the embedded certname and compare it with the configured certname                                   |
 |2017/04/18|      |Release 0.0.26                                                                                           |

--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -525,11 +525,13 @@ module MCollective
       #
       # @return [Hash] with :target and :port
       def puppetca_server
+        d_port = get_option("choria.puppetca_port", "8140")
+
         if @ca
-          {:target => @ca, :port => "8140"}
+          {:target => @ca, :port => d_port}
         else
           d_host = get_option("choria.puppetca_host", "puppet")
-          try_srv(["_x-puppet-ca._tcp", "_x-puppet._tcp"], d_host, "8140")
+          try_srv(["_x-puppet-ca._tcp", "_x-puppet._tcp"], d_host, d_port)
         end
       end
 

--- a/spec/unit/mcollective/util/choria_spec.rb
+++ b/spec/unit/mcollective/util/choria_spec.rb
@@ -579,10 +579,10 @@ module MCollective
         it "should query SRV" do
           Config.instance.stubs(:pluginconf).returns(
             "choria.puppetca_host" => "rspec.puppetca",
-            "choria.puppetca_port" => "8140"
+            "choria.puppetca_port" => "8141"
           )
           resolved = {:target => "rspec.puppetca", :port => 8144}
-          choria.expects(:try_srv).with(["_x-puppet-ca._tcp", "_x-puppet._tcp"], "rspec.puppetca", "8140").returns(resolved)
+          choria.expects(:try_srv).with(["_x-puppet-ca._tcp", "_x-puppet._tcp"], "rspec.puppetca", "8141").returns(resolved)
 
           expect(choria.puppetca_server).to eq(resolved)
         end


### PR DESCRIPTION
Previously the CA port was hard coded to 8140, this will now consult the
documented config option and use the right port

Close #265 