### PR TITLE
(#271) support upcoming puppetdb proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/05/22|271   |Support Choria Discovery Proxy                                                                           |
 |2017/05/08|265   |Consult `choria.puppetca_port` configuration when resolving the CA                                       |
 |2017/05/04|152   |Add a etcd data store                                                                                    |
 |2017/04/19|258   |Show the embedded certname and compare it with the configured certname                                   |

--- a/lib/mcollective/application/choria.rb
+++ b/lib/mcollective/application/choria.rb
@@ -194,6 +194,14 @@ module MCollective
         puts "     PuppetDB Server: %s:%s" % [puppetdb_server[:target], puppetdb_server[:port]]
         puts "      Facter Command: %s" % choria.facter_cmd
         puts "       Facter Domain: %s" % choria.facter_domain
+
+        if choria.proxied_discovery?
+          proxy_server = choria.discovery_server
+          puts "    Discovery Server: %s:%s" % [proxy_server[:target], proxy_server[:port]]
+        else
+          puts "    Discovery Server: not using a proxy"
+        end
+
         puts
 
         puts "SSL setup:"

--- a/spec/unit/mcollective/discovery/choria_spec.rb
+++ b/spec/unit/mcollective/discovery/choria_spec.rb
@@ -4,7 +4,19 @@ require "mcollective/discovery/choria"
 
 module MCollective
   describe Discovery::Choria do
-    let(:discovery) { Discovery::Choria.new({}, 10, 1, stub) }
+    let(:discovery) { Discovery::Choria.new(Util.empty_filter, 10, 1, stub) }
+    let(:choria) { discovery.choria }
+
+    describe "#discover" do
+      it "should support proxy discoveries" do
+        choria.expects(:proxied_discovery?).returns(true)
+
+        discovery.filter["cf_class"] << "puppet"
+
+        choria.expects(:proxy_discovery_query).with("classes" => ["puppet"]).returns(["node1.example.net"])
+        expect(discovery.discover).to eq(["node1.example.net"])
+      end
+    end
 
     describe "#capitalize_resource" do
       it "should correctly capitalize resources" do


### PR DESCRIPTION
This adds support for the PuppetDB proxy allow discovery requests to be
proxied through a service to assist in avoiding opening PuppetDB to
everyone