### PR TITLE
(#274) Update hiera.yaml syntax to version 5

### DIFF
--- a/module/hiera.yaml
+++ b/module/hiera.yaml
@@ -1,8 +1,12 @@
 ---
-version: 4
-datadir: "data"
+version: 5
+
+defaults:
+  datadir: "data"
+  data_hash: yaml_data
+
 hierarchy:
   - name: "plugin"
-    backend: "yaml"
+    path: "plugin.yaml"
   - name: "defaults"
-    backend: "yaml"
+    path: "defaults.yaml"

--- a/module/metadata.json
+++ b/module/metadata.json
@@ -16,6 +16,5 @@
     { "name": "choria/mcollective_util_actionpolicy", "version_requirement": ">= 2.1.0" },
     { "name": "choria/nats", "version_requirement": ">= 0.0.6" },
     { "name": "camptocamp/systemd", "version_requirement": ">= 0.3.0 < 1.0.0" }
-  ],
-  "data_provider": "hiera"
+  ]
 }


### PR DESCRIPTION
This patch updates the syntax of hiera.yaml file to version 5, as
version 4 is deprecated.