### PR TITLE
(#276) Add puppet version requirement

### DIFF
--- a/module/metadata.json
+++ b/module/metadata.json
@@ -16,5 +16,11 @@
     { "name": "choria/mcollective_util_actionpolicy", "version_requirement": ">= 2.1.0" },
     { "name": "choria/nats", "version_requirement": ">= 0.0.6" },
     { "name": "camptocamp/systemd", "version_requirement": ">= 0.3.0 < 1.0.0" }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.9.0"
+    }
   ]
 }


### PR DESCRIPTION
This commit adds a requirement for puppet version 4.9, as changes
introduced in #275 are not compatible with earlier versions.

Additionally, it's good to have required version defined.