### PR TITLE
(#267) Support a pure JSON mcollective

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ doc
 module/files/mcollective
 module/pkg
 module/CHANGELOG.md
-module/COPYING
+module/LICENSE.txt
 tmp
 coverage
 website/public

--- a/spec/unit/mcollective/security/choria_spec.rb
+++ b/spec/unit/mcollective/security/choria_spec.rb
@@ -13,6 +13,20 @@ module MCollective
       RSpec.configuration.json_schemas["mcollective::security::choria:reply:1"] = "schemas/mcollective__security__choria_reply_1.json"
     end
 
+    describe "#default_serializer" do
+      it "should default to yaml" do
+        expect(security.default_serializer).to be(:yaml)
+      end
+
+      it "should support JSON" do
+        Config.instance.expects(:pluginconf).returns(
+          "choria.security.serializer" => "JSON"
+        )
+
+        expect(security.default_serializer).to be(:json)
+      end
+    end
+
     describe "#client_pubcert_metadata" do
       it "should return correct metadata" do
         envelope = security.empty_request["envelope"]


### PR DESCRIPTION
This adds choria.security.serializer to enable a pure JSON mcollective
for mcollective 2.11.0 and later

Close #267 