### PR TITLE
(#288) serialize the inner most message seperately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/06/18|288   |Serialize the innermost body seperately from the container messages                                      |
 |2017/06/01|      |Release 0.0.27                                                                                           |
 |2017/06/01|267   |Support a pure JSON transport in preparation for a upcoming MCollective release                          |
 |2017/06/01|273   |Correctly report paths when doing a federation trace to the host the client runs on                      |


### PR DESCRIPTION
MCollective messages have the following structure:

```
( middleware protocol
  ( transport packet that travels over the middleware
    ( security plugin representation
      ( message body, for RPC request M::RPC::Request and M::RPC::Reply )
    )
  )
)
```

Here each line is a layer and should be handled seperately
by its specific part, specficially everything up to before the inner
most message is standardised and easy to specify.  The middle is no mans
land where any message or object can live and would differ from Protocol
to Protocol.

For instance discovery has just "ping" there while RPC messages have a
huge message there with varying contents based on the agent etc.

Static language cannot easily decode this inner most protocol as its
undefined and have no type hints etc.  But they can decode up to before
it and for things like federation brokers all they need is up to before
the body.

With this change the body is serialized before the wrappers are
serialized to enforce this and ensure we could decode it with Go
to build things like a new federation broker.

Attempts are made to detect old clients communicating with new Servers,
these request IDs are tracked in a 1 hour expiring Cache and should a
reply be sent for one of those requests it will be sent in the legacy
format.  Thus old clients can talk to new servers.  New clients cannot
talk to old servers.