### PR TITLE
(#282) Adjust message versioning

### DIFF
--- a/lib/mcollective/connector/nats.rb
+++ b/lib/mcollective/connector/nats.rb
@@ -227,6 +227,7 @@ module MCollective
           end
 
           data = {
+            "protocol" => "choria:transport:4",
             "data" => msg.payload,
             "headers" => {
               "federation" => {
@@ -257,6 +258,7 @@ module MCollective
         msg.discovered_hosts.each do |node|
           target = target_for(msg, node)
           data = {
+            "protocol" => "choria:transport:4",
             "data" => msg.payload,
             "headers" => target[:headers]
           }
@@ -273,6 +275,7 @@ module MCollective
       def publish_federated_broadcast(msg)
         target = target_for(msg)
         data = {
+          "protocol" => "choria:transport:4",
           "data" => msg.payload,
           "headers" => {
             "federation" => {
@@ -298,7 +301,11 @@ module MCollective
       # @param msg [Message]
       def publish_connected_broadcast(msg)
         target = target_for(msg)
-        data = {"data" => msg.payload, "headers" => target[:headers]}
+        data = {
+          "protocol" => "choria:transport:4",
+          "data" => msg.payload,
+          "headers" => target[:headers]
+        }
 
         # only happens when replying
         if received_message = msg.request

--- a/schemas/choria_secure_reply_1.json
+++ b/schemas/choria_secure_reply_1.json
@@ -5,12 +5,12 @@
     "protocol": {
       "type": "string",
       "enum": [
-        "mcollective::security::choria:reply:1"
+        "choria:secure:reply:1"
       ]
     },
     "message": {
       "type": "string",
-      "description": "YAML encoded mcollective:reply:3"
+      "description": "YAML encoded choria:reply:1"
     },
     "hash": {
       "type": "string",

--- a/schemas/choria_secure_request_1.json
+++ b/schemas/choria_secure_request_1.json
@@ -5,12 +5,12 @@
     "protocol": {
       "type": "string",
       "enum": [
-        "mcollective::security::choria:request:1"
+        "choria:secure:request:1"
       ]
     },
     "message": {
       "type": "string",
-      "description": "YAML encoded mcollective:request:3"
+      "description": "YAML encoded choria:request:1"
     },
     "signature": {
       "type": "string",

--- a/spec/unit/mcollective/connector/nats_spec.rb
+++ b/spec/unit/mcollective/connector/nats_spec.rb
@@ -211,6 +211,7 @@ module MCollective
         choria.expects(:federation_collectives).returns(["net_a", "net_b"])
 
         msg1 = {
+          "protocol" => "choria:transport:4",
           "data" => "rspec",
           "headers" => {
             "mc_sender" => "rspec_identity",
@@ -240,6 +241,7 @@ module MCollective
 
         choria.expects(:federation_collectives).returns(["net_a", "net_b"])
         msg1 = {
+          "protocol" => "choria:transport:4",
           "data" => "rspec",
           "headers" => {
             "mc_sender" => "rspec_identity",
@@ -252,6 +254,7 @@ module MCollective
         }
 
         msg2 = {
+          "protocol" => "choria:transport:4",
           "data" => "rspec",
           "headers" => {
             "mc_sender" => "rspec_identity",
@@ -303,6 +306,7 @@ module MCollective
         msg.type = :request
 
         JSON.expects(:dump).with(
+          "protocol" => "choria:transport:4",
           "data" => "rspec",
           "headers" => {
             "mc_sender" => "rspec_identity",


### PR DESCRIPTION
This adjusts the versioning of the various protocol messages to be all
version 1 and also add protocol headers to the transport messages.

New version strings are:

   * choria:reply:1 and choria:request:1
   * choria:secure:reply:1 and choria:secure:request:1
   * choria:transport:1

Thus the whole grouping of messages represents version 1 rather than the
mish mash of v1 and v3 that all somehow combined.  Realistically it will
be impossible to version this stuff in finer level than as a group, so
this makes the whole group the same version

This has the same compatibility story as 8ebc3b158 and will ship at the
same time - Old clients can talk to new servers.  New clients cannot
talk to old servers.