### PR TITLE
(#296) Use base64 for encoding reply hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/06/30|296   |Use base64 not hex encoding for reply hashes                                                             |
 |2017/06/18|288   |Serialize the innermost body seperately from the container messages                                      |
 |2017/06/01|      |Release 0.0.27                                                                                           |
 |2017/06/01|267   |Support a pure JSON transport in preparation for a upcoming MCollective release                          |

--- a/lib/mcollective/security/choria.rb
+++ b/lib/mcollective/security/choria.rb
@@ -616,7 +616,7 @@ module MCollective
       # @param string [String] the string to hash
       # @return [String]
       def hash(string)
-        OpenSSL::Digest.new("sha256", string).to_s
+        OpenSSL::Digest.new("sha256", string).base64digest
       end
 
       # Retrieves the current time in UTC

--- a/spec/unit/mcollective/security/choria_spec.rb
+++ b/spec/unit/mcollective/security/choria_spec.rb
@@ -513,7 +513,7 @@ module MCollective
 
     describe "#hash" do
       it "should produce a valid SHA256 hash" do
-        expect(security.hash("too many secrets")).to eq("624fa374a759deff04da9e9d99b7e7f9937d9410401c421c38ca78973b98293a")
+        expect(security.hash("too many secrets")).to eq("Yk+jdKdZ3v8E2p6dmbfn+ZN9lBBAHEIcOMp4lzuYKTo=")
       end
     end
 


### PR DESCRIPTION
The hash computed for reply data was inadvertantly done using Hex
encoding, this is the only hex encoded thing in the entire protocol
while there are several other base64 encoded bits.

So for consistancy this is changed.  We do not validate this hash at
present so this has no impact