### PR TITLE
(#300) adding the ability to use supervisord as a service provider

### DIFF
--- a/module/metadata.json
+++ b/module/metadata.json
@@ -15,7 +15,8 @@
     { "name": "choria/mcollective_agent_filemgr", "version_requirement": ">= 1.1.0" },
     { "name": "choria/mcollective_util_actionpolicy", "version_requirement": ">= 2.1.0" },
     { "name": "choria/nats", "version_requirement": ">= 0.0.6" },
-    { "name": "camptocamp/systemd", "version_requirement": ">= 0.3.0 < 1.0.0" }
+    { "name": "camptocamp/systemd", "version_requirement": ">= 0.3.0 < 1.0.0" },
+    { "name": "ajcrowe/supervisord", "version_requirement": ">= 0.6.1" }
   ],
   "requirements": [
     {


### PR DESCRIPTION
Optionally uses ajcrowe/supervisord to run the little federated broker daemons instead of systemd, which makes it useful on CentOS 6 systems.