### PR TITLE
(#305) Handle JSON encoded node inventory data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/08/02|305   |Handle the case where node inventory data is JSON encoded correctly in playbooks                         |
 |2017/08/02|      |Release 0.0.28                                                                                           |
 |2017/07/27|301   |Support using supervisord to manage the federation brokers                                               |
 |2017/08/02|298   |Update `nats-pure` gem to `0.2.4`                                                                        |

--- a/lib/mcollective/util/playbook/uses.rb
+++ b/lib/mcollective/util/playbook/uses.rb
@@ -28,7 +28,21 @@ module MCollective
             "silent" => true
           )
 
-          rpc.run
+          success, msg, inventory = rpc.run
+
+          # rpcutil#agent_inventory is a hash in a hash not managed by the DDL
+          # this is not handled by the JSON encoding magic that does DDL based
+          # symbol and string conversion so we normalise the data always to symbol
+          # based structures
+          inventory.each do |node|
+            node["data"][:agents].each do |agent|
+              agent.keys.each do |key|
+                agent[key.intern] = agent.delete(key) if key.is_a?(String)
+              end
+            end
+          end
+
+          [success, msg, inventory]
         end
 
         # Validates agent versions on nodes


### PR DESCRIPTION
Should mcollective be configured in JSON safe mode the
rpcutil#agent_inventory data needs to be normalized to use symbols as
the DDL based system would not do it