### PR TITLE
(#310) Support using fact dot notation in choria discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/08/11|310   |Support dot notation for facts when using choria discovery method                                        |
 |2017/08/09|192   |Add an `assert` option to the `mcollective` task using JGrep, deprecate `mcollective_assert`             |
 |2017/08/02|305   |Handle the case where node inventory data is JSON encoded correctly in playbooks                         |
 |2017/08/02|      |Release 0.0.28                                                                                           |

--- a/lib/mcollective/discovery/choria.rb
+++ b/lib/mcollective/discovery/choria.rb
@@ -130,19 +130,17 @@ module MCollective
           when "=~"
             regex = string_regexi(value)
 
-            'facts {name = "%s" and value ~ "%s"}' % [fact, regex]
+            'inventory {facts.%s ~ "%s"}' % [fact, regex]
           when "=="
-            'facts {name = "%s" and value = "%s"}' % [fact, value]
+            'inventory {facts.%s = "%s"}' % [fact, value]
           when "!="
-            'facts {name = "%s" and !(value = "%s")}' % [fact, value]
+            'inventory {!(facts.%s = "%s")}' % [fact, value]
           when ">=", ">", "<=", "<"
-            if numeric?(value)
-              'facts {name = "%s" and value %s %s}' % [fact, operator, value]
-            else
-              'facts {name = "%s" and value %s "%s"}' % [fact, operator, value]
-            end
+            raise("Do not know how to do string fact comparisons using the '%s' operator with PuppetDB" % operator) unless numeric?(value)
+
+            "inventory {facts.%s %s %s}" % [fact, operator, value]
           else
-            raise("Do not know how to do fact comparisons using operator `%s` using PuppetDB" % operator)
+            raise("Do not know how to do fact comparisons using the '%s' operator with PuppetDB" % operator)
           end
         end
 

--- a/spec/unit/mcollective/discovery/choria_spec.rb
+++ b/spec/unit/mcollective/discovery/choria_spec.rb
@@ -63,29 +63,31 @@ module MCollective
       it "should support =~" do
         expect(
           discovery.discover_facts([:fact => "f", :operator => "=~", :value => "v"])
-        ).to eq('facts {name = "f" and value ~ "[vV]"}')
+        ).to eq('inventory {facts.f ~ "[vV]"}')
       end
 
       it "should support ==" do
         expect(
           discovery.discover_facts([:fact => "f", :operator => "==", :value => "v"])
-        ).to eq('facts {name = "f" and value = "v"}')
+        ).to eq('inventory {facts.f = "v"}')
       end
 
       it "should support !=" do
         expect(
           discovery.discover_facts([:fact => "f", :operator => "!=", :value => "v"])
-        ).to eq('facts {name = "f" and !(value = "v")}')
+        ).to eq('inventory {!(facts.f = "v")}')
+      end
+
+      it "should fail for other operators when comparing strings" do
+        expect do
+          discovery.discover_facts([:fact => "f", :operator => ">=", :value => "v"])
+        end.to raise_error("Do not know how to do string fact comparisons using the '>=' operator with PuppetDB")
       end
 
       it "should support other operators" do
         expect(
-          discovery.discover_facts([:fact => "f", :operator => ">=", :value => "v"])
-        ).to eq('facts {name = "f" and value >= "v"}')
-
-        expect(
           discovery.discover_facts([:fact => "f", :operator => ">=", :value => 1])
-        ).to eq('facts {name = "f" and value >= 1}')
+        ).to eq("inventory {facts.f >= 1}")
       end
     end
 


### PR DESCRIPTION
This uses the inventory {} collection rather than facts one when
querying PuppetDB for facts which enables dot based notation in fact
searches

    -W "os.distro.id!=CentOS"

Will now work along with most other things.

The one thing I can't yet figure out how to support `<=`, `<`, `>` and
`>=` with string comparisons as it appears PQL does not support those,
this might well be a bad thing but for now assuming the gain outweighs
the loss.  Anyway it appears to me those were just broken before, they
would result in huge PuppetDB backtraces.  Now it will produce the right
error.