### PR TITLE
remove dependency on ajcrowe/supervisord for #308 

### DIFF
--- a/module/metadata.json
+++ b/module/metadata.json
@@ -15,8 +15,7 @@
     { "name": "choria/mcollective_agent_filemgr", "version_requirement": ">= 1.1.0" },
     { "name": "choria/mcollective_util_actionpolicy", "version_requirement": ">= 2.1.0" },
     { "name": "choria/nats", "version_requirement": ">= 0.0.6" },
-    { "name": "camptocamp/systemd", "version_requirement": ">= 0.3.0 < 1.0.0" },
-    { "name": "ajcrowe/supervisord", "version_requirement": ">= 0.6.1" }
+    { "name": "camptocamp/systemd", "version_requirement": ">= 0.3.0 < 1.0.0" }
   ],
   "requirements": [
     {


### PR DESCRIPTION
Removes the metadata to pull in ajcrowe/supervisord, but leaves the Puppet code there.