### PR TITLE
(#314) Fix fact filters in JSON mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/08/18|314   |Fix fact filters in JSON transport mode                                                                  |
 |2017/08/18|307   |When the client is run as root raise an informative error rather than fail silently                      |
+|2017/08/16|308   |Remove hard dependency on ajcrowe/supervisord                                                            |
 |2017/08/11|310   |Support dot notation for facts when using choria discovery method                                        |
 |2017/08/09|192   |Add an `assert` option to the `mcollective` task using JGrep, deprecate `mcollective_assert`             |
 |2017/08/02|305   |Handle the case where node inventory data is JSON encoded correctly in playbooks                         |

--- a/lib/mcollective/security/choria.rb
+++ b/lib/mcollective/security/choria.rb
@@ -666,6 +666,34 @@ module MCollective
         }
       end
 
+      # Converts a choria filter into a legacy format
+      #
+      # Choria filters have strings for fact filter keys, mcollective expect symbols
+      #
+      # @param filter [Hash] the input filter
+      # @return [Hash] a new filter converted to legacy format
+      def to_legacy_filter(filter)
+        return filter unless filter.include?("fact")
+
+        new = {}
+
+        filter.each do |key, value|
+          new[key] = value
+
+          next unless key == "fact"
+
+          new["fact"] = value.map do |ff|
+            {
+              :fact => ff.fetch(:fact, ff["fact"]),
+              :operator => ff.fetch(:operator, ff["operator"]),
+              :value => ff.fetch(:value, ff["value"])
+            }
+          end
+        end
+
+        new
+      end
+
       # Converts a choria:request:1 to a legacy format
       #
       # @return [Hash]
@@ -674,7 +702,7 @@ module MCollective
           :body => body["message"],
           :senderid => body["envelope"]["senderid"],
           :requestid => body["envelope"]["requestid"],
-          :filter => body["envelope"]["filter"],
+          :filter => to_legacy_filter(body["envelope"]["filter"]),
           :collective => body["envelope"]["collective"],
           :agent => body["envelope"]["agent"],
           :callerid => body["envelope"]["callerid"],

--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -373,7 +373,7 @@ module MCollective
           return false
         end
 
-        Log.info("Verified certificate %s against CA %s" % [incoming.subject.to_s, ca.subject.to_s]) if log
+        Log.debug("Verified certificate %s against CA %s" % [incoming.subject.to_s, ca.subject.to_s]) if log
 
         cn_parts = incoming.subject.to_a.select {|c| c[0] == "CN"}.flatten
 

--- a/spec/unit/mcollective/security/choria_spec.rb
+++ b/spec/unit/mcollective/security/choria_spec.rb
@@ -537,6 +537,34 @@ module MCollective
       end
     end
 
+    describe "#to_legacy_filter" do
+      let(:legacy) do
+        {
+          "agent" => ["rspec"],
+          "fact" => [
+            {:fact => "rspec", :operator => "==", :value => "1"},
+            {:fact => "rspec", :operator => "==", :value => "2"}
+          ]
+        }
+      end
+
+      it "should convert choria filters" do
+        cf = {
+          "agent" => ["rspec"],
+          "fact" => [
+            {"fact" => "rspec", "operator" => "==", "value" => "1"},
+            {"fact" => "rspec", "operator" => "==", "value" => "2"}
+          ]
+        }
+
+        expect(security.to_legacy_filter(cf)).to eq(legacy)
+      end
+
+      it "should leave legacy filters alone" do
+        expect(security.to_legacy_filter(legacy)).to eq(legacy)
+      end
+    end
+
     describe "#to_legacy_reply" do
       it "should produce a valid reply" do
         body = security.empty_reply


### PR DESCRIPTION
MCollective expects the key "facts" to hold :fact, :operator and :value
but in JSON mode we passed "fact", "operator' and "value"

This does additional to_legacy conversion ensuring fact filters keep
working

Close #314 