### PR TITLE
(#192) correctly report assertion failures

### DIFF
--- a/lib/mcollective/util/playbook/tasks/mcollective_task.rb
+++ b/lib/mcollective/util/playbook/tasks/mcollective_task.rb
@@ -119,14 +119,14 @@ module MCollective
             end
 
             success = request_success?(stats)
-            assert_matched = -1
+            assert_failed = -1
 
             if @assertion && success
-              passed, assert_matched = assert_replies(replies)
+              passed, assert_failed = assert_replies(replies)
               if passed
-                Log.info("Assertion '%s' passed on all %d nodes" % [@assertion, assert_matched])
+                Log.info("Assertion '%s' passed on all %d nodes" % [@assertion, replies.size])
               else
-                Log.warn("Assertion '%s' matched on %d/%d nodes" % [@assertion, assert_matched, replies.size])
+                Log.warn("Assertion '%s' failed on %d/%d nodes" % [@assertion, assert_failed, replies.size])
                 success = false
               end
             end
@@ -138,9 +138,8 @@ module MCollective
               msg = success_message(stats) unless msg
 
               [true, msg, reply_data]
-            elsif assert_matched > -1
-              failed = stats.okcount - assert_matched
-              [false, "Failed request %s for %s#%s assertion failed on %d node(s)" % [stats.requestid, @agent, @action, failed], reply_data]
+            elsif assert_failed > -1
+              [false, "Failed request %s for %s#%s assertion failed on %d node(s)" % [stats.requestid, @agent, @action, assert_failed], reply_data]
             else
               failed = stats.failcount + stats.noresponsefrom.size
               [false, "Failed request %s for %s#%s on %d failed node(s)" % [stats.requestid, @agent, @action, failed], reply_data]

--- a/spec/unit/mcollective/util/playbook/tasks/mcollective_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/mcollective_task_spec.rb
@@ -245,7 +245,7 @@ module MCollective
             it "should validate assertions for succesful requests" do
               stats = stub(:requestid => "123", :failcount => 0, :noresponsefrom => [], :okcount => 1, :totaltime => 2)
               task.instance_variable_set("@assertion", "enabled=false")
-              task.expects(:assert_replies).with([rpc_result]).returns([true, 1])
+              task.expects(:assert_replies).with([rpc_result]).returns([true, 0])
 
               rr = task.run_result(stats, [rpc_result])
 
@@ -256,12 +256,12 @@ module MCollective
             it "should log failed assertions" do
               stats = stub(:requestid => "123", :failcount => 0, :noresponsefrom => [], :okcount => 2, :totaltime => 2)
               task.instance_variable_set("@assertion", "enabled=false")
-              task.expects(:assert_replies).with([rpc_result, rpc_result]).returns([false, 1])
+              task.expects(:assert_replies).with([rpc_result, rpc_result]).returns([false, 2])
 
               rr = task.run_result(stats, [rpc_result, rpc_result])
 
               expect(rr[0]).to be(false)
-              expect(rr[1]).to eq("Failed request 123 for puppet#disable assertion failed on 1 node(s)")
+              expect(rr[1]).to eq("Failed request 123 for puppet#disable assertion failed on 2 node(s)")
             end
           end
 


### PR DESCRIPTION
The assertion tester returns failed nodes not succesful nodes, the
result reporter assumed it reported succesful nodes so the logging was
all kinds of wrong