### PR TITLE
(#290) Strip spaces from host/port lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/08/19|290   |Strip spaces off comma separated host lists to allow for space between hosts
 |2017/08/18|314   |Fix fact filters in JSON transport mode                                                                  |
 |2017/08/18|307   |When the client is run as root raise an informative error rather than fail silently                      |
 |2017/08/16|308   |Remove hard dependency on ajcrowe/supervisord                                                            |

--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -438,7 +438,7 @@ module MCollective
       def server_resolver(config_option, srv_records, default_host=nil, default_port=nil)
         if servers = get_option(config_option, nil)
           hosts = servers.split(",").map do |server|
-            server.split(":")
+            server.split(":").map(&:strip)
           end
 
           return hosts

--- a/spec/unit/mcollective/util/choria_spec.rb
+++ b/spec/unit/mcollective/util/choria_spec.rb
@@ -249,11 +249,12 @@ module MCollective
 
       describe "#server_resolver" do
         it "should support config" do
-          Config.instance.stubs(:pluginconf).returns("choria.middleware_hosts" => "1.net:4222,2.net:4223")
+          Config.instance.stubs(:pluginconf).returns("choria.middleware_hosts" => "1.net:4222,2.net:4223, 3.net:4224 ")
           expect(choria.server_resolver("choria.middleware_hosts", ["srv_record"], "h", "1")).to eq(
             [
               ["1.net", "4222"],
-              ["2.net", "4223"]
+              ["2.net", "4223"],
+              ["3.net", "4224"]
             ]
           )
         end


### PR DESCRIPTION
When hosts can be listed as a comma separated list of nodes like in
server lists these had to have no spaces between the commas or trailing
spaces or it would fail

This strips any trailing and leading spaces from the hosts and ports

Closes #290 