### PR TITLE
(#322) Fix fetching certificates

### DIFF
--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -854,7 +854,7 @@ module MCollective
 
         server = puppetca_server
 
-        req = http_get("/puppet-ca/v1/certificate/ca", "Content-Type" => "text/plain")
+        req = http_get("/puppet-ca/v1/certificate/ca?environment=production", "Accept" => "text/plain")
         resp, _ = https(server).request(req)
 
         if resp.code == "200"
@@ -896,7 +896,7 @@ module MCollective
       def attempt_fetch_cert
         return true if has_client_public_cert?
 
-        req = http_get("/puppet-ca/v1/certificate/%s" % certname, "Accept" => "text/plain")
+        req = http_get("/puppet-ca/v1/certificate/%s?environment=production" % certname, "Accept" => "text/plain")
         resp, _ = https(puppetca_server).request(req)
 
         if resp.code == "200"

--- a/spec/unit/mcollective/util/choria_spec.rb
+++ b/spec/unit/mcollective/util/choria_spec.rb
@@ -460,7 +460,7 @@ module MCollective
 
           it "should return false on failure" do
             choria.expects(:has_client_public_cert?).returns(false)
-            stub_request(:get, "https://puppetca:8140/puppet-ca/v1/certificate/rspec.cert")
+            stub_request(:get, "https://puppetca:8140/puppet-ca/v1/certificate/rspec.cert?environment=production")
               .with(:headers => headers)
               .to_return(:status => 404, :body => "success")
 
@@ -475,7 +475,7 @@ module MCollective
             File.expects(:open).with("/ssl/certs/rspec.cert.pem", "w", 0o0644).yields(file)
 
             choria.expects(:has_client_public_cert?).returns(false)
-            stub_request(:get, "https://puppetca:8140/puppet-ca/v1/certificate/rspec.cert")
+            stub_request(:get, "https://puppetca:8140/puppet-ca/v1/certificate/rspec.cert?environment=production")
               .with(:headers => headers)
               .to_return(:status => 200, :body => cert)
 


### PR DESCRIPTION
According to Puppet's documentation, an "environment" parameter is
required (and is unused) when the Puppet master runs from Rack or
WEBrick.
https://docs.puppet.com/puppet/5.0/http_api/http_certificate_request.html#find

Add this environment at two places where it is missing.

While here, fix headers sent when fetching the CA.

These problems where discovered at the [First User](http://choria.io/docs/deployment/first-user/) stage of Choria documentation:

```
% mco choria request_cert
Encountered a critical error: Failed to fetch CA from puppet:8140: 400: Bad Request
% # Some hacking to discover the missing "?environment=production"
% mco choria request_cert
Encountered a critical error: Failed to fetch CA from puppet:8140: 406: Not Acceptable
% # Some hacking to discover the Content-Type / Accept confusion
```