### PR TITLE
(#323) Support disabling TLS on the connector

### DIFF
--- a/lib/mcollective/connector/nats.rb
+++ b/lib/mcollective/connector/nats.rb
@@ -77,6 +77,11 @@ module MCollective
           }
         }
 
+        if $choria_unsafe_disable_nats_tls # rubocop:disable Style/GlobalVars
+          Log.warn("Disabling TLS in NATS connector, this is not a production supported setup")
+          parameters.delete(:tls)
+        end
+
         servers = server_list
 
         unless servers.empty?


### PR DESCRIPTION
For testing scenarios where one might run many many instances of Choria
on a single node TLS might just be too hard to setup or too costly on
CPU

This allows programs to disable TLS on NATS by setting
$choria_unsafe_disable_nats_tls to true in their code