### PR TITLE
(#325) support inputs that save provided values to the datastores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
-|2017/08/19|      |Release 0.1.0                                                                                           |
-|2017/08/19|290   |Strip spaces off comma separated host lists to allow for space between hosts
+|2017/09/10|325   |Support saving CLI provided inputs to the data stores automatically                                      |
+|2017/08/19|      |Release 0.1.0                                                                                            |
+|2017/08/19|290   |Strip spaces off comma separated host lists to allow for space between hosts                             |
 |2017/08/18|314   |Fix fact filters in JSON transport mode                                                                  |
 |2017/08/18|307   |When the client is run as root raise an informative error rather than fail silently                      |
 |2017/08/16|308   |Remove hard dependency on ajcrowe/supervisord                                                            |

--- a/spec/fixtures/playbooks/playbook.yaml
+++ b/spec/fixtures/playbooks/playbook.yaml
@@ -54,6 +54,13 @@ inputs:
     dynamic: true
     data: "mem_store/data_backed"
 
+  data_backed_save:
+    description: data source backed input
+    type: String
+    save: true
+    validation: ":string"
+    data: "mem_store/data_backed"
+
 nodes:
   load_balancers:
     type: mcollective

--- a/spec/unit/mcollective/util/playbook/inputs_spec.rb
+++ b/spec/unit/mcollective/util/playbook/inputs_spec.rb
@@ -10,10 +10,28 @@ module MCollective
         let(:inputs) { Inputs.new(playbook) }
         let(:playbook_fixture) { YAML.load(File.read("spec/fixtures/playbooks/playbook.yaml")) }
 
+        describe "#save_to_datastore" do
+          it "should not attempt to save without a specific value" do
+            inputs.from_hash(playbook_fixture["inputs"])
+            expect { inputs.save_to_datastore("cluster") }.to raise_error("Input cluster has no value, cannot store it")
+          end
+
+          it "should save the right key and value" do
+            inputs.from_hash(playbook_fixture["inputs"])
+            inputs.save_during_prepare = false
+
+            inputs.prepare("cluster" => "beta", "two" => "foo", "data_backed_save" => "set_value")
+
+            ds.expects(:write).with("mem_store/data_backed", "set_value")
+
+            inputs.save_to_datastore("data_backed_save")
+          end
+        end
+
         describe "#dyanmic_keys" do
           it "should find the right keys" do
             inputs.from_hash(playbook_fixture["inputs"])
-            expect(inputs.dynamic_keys).to eq(["data_backed", "forced_dynamic"])
+            expect(inputs.dynamic_keys).to eq(["data_backed", "forced_dynamic", "data_backed_save"])
           end
         end
 
@@ -48,7 +66,7 @@ module MCollective
         describe "#keys" do
           it "should return the right keys" do
             inputs.from_hash(playbook_fixture["inputs"])
-            expect(inputs.keys).to eq(["cluster", "two", "data_backed", "forced_dynamic"])
+            expect(inputs.keys).to eq(["cluster", "two", "data_backed", "forced_dynamic", "data_backed_save"])
           end
         end
 
@@ -149,10 +167,10 @@ module MCollective
 
           it "should mark dynamic inputs with data given as static" do
             inputs.from_hash(playbook_fixture["inputs"])
-            expect(inputs.dynamic_keys).to eq(["data_backed", "forced_dynamic"])
+            expect(inputs.dynamic_keys).to eq(["data_backed", "forced_dynamic", "data_backed_save"])
             expect(inputs.static_keys).to eq(["cluster", "two"])
             inputs.prepare("cluster" => "beta", "two" => "foo", "data_backed" => "1")
-            expect(inputs.dynamic_keys).to eq(["forced_dynamic"])
+            expect(inputs.dynamic_keys).to eq(["forced_dynamic", "data_backed_save"])
             expect(inputs.static_keys).to eq(["cluster", "two", "data_backed"])
           end
 
@@ -162,6 +180,12 @@ module MCollective
             expect(inputs.dynamic_keys).to include("forced_dynamic")
             ds.expects(:read).with("mem_store/data_backed").returns("rspec_ds")
             expect(inputs["forced_dynamic"]).to eq("rspec_ds")
+          end
+
+          it "should save static inputs with save set" do
+            inputs.from_hash(playbook_fixture["inputs"])
+            ds.expects(:write).with("mem_store/data_backed", "data_to_save")
+            inputs.prepare("cluster" => "beta", "two" => "foo", "forced_dynamic" => "rspec_override", "data_backed_save" => "data_to_save")
           end
         end
 
@@ -259,7 +283,7 @@ module MCollective
         describe "#from_hash" do
           it "should store the data" do
             inputs.from_hash(playbook_fixture["inputs"])
-            expect(inputs.keys).to eq(["cluster", "two", "data_backed", "forced_dynamic"])
+            expect(inputs.keys).to eq(["cluster", "two", "data_backed", "forced_dynamic", "data_backed_save"])
           end
 
           it "should set the defaults" do

--- a/spec/unit/mcollective/util/playbook/report_spec.rb
+++ b/spec/unit/mcollective/util/playbook/report_spec.rb
@@ -150,7 +150,7 @@ module MCollective
 
             report.store_dynamic_inputs
 
-            expect(report.instance_variable_get("@inputs")["dynamic"]).to eq(["data_backed", "forced_dynamic"])
+            expect(report.instance_variable_get("@inputs")["dynamic"]).to eq(["data_backed", "forced_dynamic", "data_backed_save"])
           end
         end
 


### PR DESCRIPTION
Data stores can be used to store invocation data so that future
invocations remember and reuse values once given, this is a great
usability short cut but requires a bunch of data tasks to accomplish
today

You can now make a input thats set to `save` and it will do this for you
magically:

    git_repo:
      description: Git Repository to use during release
      type: String
      save: true
      validation: ":string"
      data: "data/git_repo"

This will if the git_repo is provided specifically on the CLI save it
to the data store, in future if you give the value on the CLI again that
will be used however if you do not, it will use the previously given
value