### PR TITLE
(#333) Fix rubocop induced problems

### DIFF
--- a/lib/mcollective/application/playbook.rb
+++ b/lib/mcollective/application/playbook.rb
@@ -123,7 +123,7 @@ module MCollective
 
       def run_command
         pb_config = configuration.clone
-        pb_config.each_key {|k| k.to_s.start_with?("__") && pb_config.delete(k)}
+        pb_config.delete_if {|k, _| k.to_s.start_with?("__")}
 
         pb = playbook(configuration[:__playbook_file], configuration[:__loglevel])
 

--- a/lib/mcollective/util/playbook/uses.rb
+++ b/lib/mcollective/util/playbook/uses.rb
@@ -36,7 +36,7 @@ module MCollective
           # based structures
           inventory.each do |node|
             node["data"][:agents].each do |agent|
-              agent.each_key do |key|
+              agent.keys.each do |key| # rubocop:disable Performance/HashEachMethods
                 agent[key.intern] = agent.delete(key) if key.is_a?(String)
               end
             end


### PR DESCRIPTION
While fixing rubocop.latest complaints some bugs were introduced around
itterating a hash and modifying it at the same time

This fixes that.  Rubocop is cancer.