### PR TITLE
(#329) Allow $schema in playbooks

### DIFF
--- a/lib/mcollective/util/playbook.rb
+++ b/lib/mcollective/util/playbook.rb
@@ -87,7 +87,7 @@ module MCollective
         in_context("validation") do
           failed = false
 
-          valid_keys = (@metadata.keys + ["uses", "inputs", "locks", "data_stores", "nodes", "tasks", "hooks", "macros"])
+          valid_keys = (@metadata.keys + ["uses", "inputs", "locks", "data_stores", "nodes", "tasks", "hooks", "macros", "$schema"])
           invalid_keys = @playbook_data.keys - valid_keys
 
           unless invalid_keys.empty?


### PR DESCRIPTION
This will allow VS Code to do JSON Schema validation against playbooks
in YAML format