### PR TITLE
(#348) Allow playbooks to be written using the Plan DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Choria Orchestrator
 ===================
 
 A distribution of plugins for MCollective designed to give a very smooth and streamlined experience
-in getting started when using the Puppet 4 AIO connected to a Puppet Server.
+in getting started when using modern Puppet connected to a Puppet Server.
 
 See [choria.io](http://choria.io) for a deployment guide.
 

--- a/lib/mcollective/util/bolt_support.rb
+++ b/lib/mcollective/util/bolt_support.rb
@@ -1,0 +1,139 @@
+require "mcollective"
+require_relative "choria"
+require_relative "playbook"
+
+module MCollective
+  module Util
+    class BoltSupport
+      def choria
+        @__choria ||= Choria.new
+      end
+
+      # Converts the current Puppet loglevel to one we understand
+      #
+      # @return ["debug", "info", "warn", "error", "fatal"]
+      def self.loglevel
+        case Puppet::Util::Log.level
+        when :notice
+          "warn"
+        when :warning
+          "warn"
+        when :err
+          "error"
+        when :alert, :emerg, :crit
+          "fatal"
+        else
+          Puppet::Util::Log.level.to_s
+        end
+      end
+
+      # Configures MCollective and initialize the Bolt Support class
+      #
+      # @return [BoltSupport]
+      def self.init_choria
+        unless Config.instance.configured
+          Config.instance.loadconfig(Util.config_file_for_user)
+        end
+
+        new
+      end
+
+      # Creates a configured instance of the Playbook
+      #
+      # @return [Playbook]
+      def playbook
+        @_playbook ||= begin
+                         pb = Playbook.new("debug")
+                         pb.set_logger_level
+                         pb
+                       end
+      end
+
+      def nodes
+        @_nodes ||= Playbook::Nodes.new(playbook)
+      end
+
+      # Discovers nodes using playbook node sets
+      #
+      # @param type [String] a known node set type like `terraform`
+      # @param properties [Hash] properties valid for the node set type
+      def discover_nodes(type, properties)
+        uses_properties = properties.delete("uses") || {}
+        playbook.uses.from_hash(uses_properties)
+
+        nodes.from_hash("task_nodes" => properties.merge(
+          "type" => type,
+          "uses" => uses_properties.keys
+        ))
+
+        nodes.prepare
+        nodes["task_nodes"]
+      end
+
+      # Retrieves a data item from a data store
+      #
+      # @param item [String] the item to fetch
+      # @param properties [Hash] the data source properties
+      def data_read(item, properties)
+        playbook.data_stores.from_hash("plan_store" => properties)
+        playbook.data_stores.prepare
+        playbook.data_stores.read("plan_store/%s" % item)
+      end
+
+      # Writes a value to a data store
+      #
+      # @param item [String] the item to fetch
+      # @param value [String] the item to fetch
+      # @param properties [Hash] the data source properties
+      # @return [String] the data that was written
+      def data_write(item, value, properties)
+        config = {"plan_store" => properties}
+
+        playbook.data_stores.from_hash(config)
+        playbook.data_stores.prepare
+        playbook.data_stores.write("plan_store/%s" % item, value)
+      end
+
+      # Performs a block within a lock in a data store
+      #
+      # @param item [String] the lock key
+      # @param properties [Hash] the data source properties
+      def data_lock(item, properties, &blk)
+        locked = false
+        lock_path = "plan_store/%s" % item
+        config = {"plan_store" => properties}
+
+        playbook.data_stores.from_hash(config)
+        playbook.data_stores.prepare
+
+        playbook.data_stores.lock(lock_path)
+        locked = true
+
+        yield
+      ensure
+        playbook.data_stores.release(lock_path) if locked
+      end
+
+      # Runs a playbook task and return execution results
+      #
+      # @param type [String] the task type
+      # @param properties [Hash] properties passed to the task
+      # @return [Hash] formatted for Puppet::Pops::Types::ExecutionResult#from_bolt
+      def run_task(type, properties)
+        tasks = playbook.tasks.load_tasks([type => properties], "tasks")
+
+        playbook.tasks.run_task(tasks[0], "plan", false)
+
+        result = tasks[0][:result]
+        runner = tasks[0][:runner]
+
+        execution_result = runner.to_execution_result([result.success, result.msg, result.data])
+        fail_ok = properties.fetch("fail_ok", false)
+
+        return execution_result if result.success
+        return execution_result if fail_ok
+        raise(result.msg)
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/playbook.rb
+++ b/lib/mcollective/util/playbook.rb
@@ -15,7 +15,7 @@ module MCollective
       include TemplateUtil
 
       attr_accessor :input_data, :context
-      attr_reader :metadata, :report, :data_stores
+      attr_reader :metadata, :report, :data_stores, :uses, :tasks
 
       def initialize(loglevel=nil)
         @loglevel = loglevel

--- a/lib/mcollective/util/playbook/nodes/mcollective_nodes.rb
+++ b/lib/mcollective/util/playbook/nodes/mcollective_nodes.rb
@@ -34,7 +34,7 @@ module MCollective
           # @todo discovery
           # @return [RPC::Client]
           def create_and_configure_client
-            client = RPC::Client.new(@agents[0], :configfile => Util.config_file_for_user)
+            client = RPC::Client.new(@agents[0], :configfile => Util.config_file_for_user, :options => Util.default_options)
             client.progress = false
             client.discovery_method = @discovery_method
 

--- a/lib/mcollective/util/playbook/tasks.rb
+++ b/lib/mcollective/util/playbook/tasks.rb
@@ -175,6 +175,8 @@ module MCollective
               @tasks[set] << task_data
             end
           end
+
+          @tasks[set]
         end
 
         def from_hash(data)

--- a/lib/mcollective/util/playbook/tasks/bolt_task.rb
+++ b/lib/mcollective/util/playbook/tasks/bolt_task.rb
@@ -137,6 +137,10 @@ module MCollective
             Time.now
           end
 
+          def to_execution_result(results)
+            results[2]
+          end
+
           def run
             results = []
             start = current_time

--- a/lib/mcollective/util/playbook/tasks/data_task.rb
+++ b/lib/mcollective/util/playbook/tasks/data_task.rb
@@ -32,6 +32,20 @@ module MCollective
             raise("A value is needed when writing") if @action == "write" && @value.nil?
           end
 
+          def to_execution_result(results)
+            result = {
+              "value" => results[2].first,
+              "error" => {
+                "msg" => results[1]
+              }
+            }
+
+            result.delete("error") if results[0]
+            result.delete("value") if result["value"].nil?
+
+            {"localhost" => result}
+          end
+
           def from_hash(properties)
             @action = properties["action"]
             @key = properties["key"]

--- a/lib/mcollective/util/playbook/tasks/graphite_event_task.rb
+++ b/lib/mcollective/util/playbook/tasks/graphite_event_task.rb
@@ -19,15 +19,19 @@ module MCollective
           end
 
           def webhook_task
-            webhook = Tasks::WebhookTask.new(@playbook)
+            return @__webhook if @__webhook
 
-            webhook.from_hash(
+            @__webhook = Tasks::WebhookTask.new(@playbook)
+
+            @__webhook.from_hash(
               "description" => @description,
               "headers" => @headers,
               "uri" => @graphite,
               "method" => "POST",
               "data" => request
             )
+
+            @__webhook
           end
 
           def validate_configuration!
@@ -37,6 +41,10 @@ module MCollective
             raise("'tags' should be an array") unless @tags.is_a?(Array)
             raise("'headers' should be a hash") unless @headers.is_a?(Hash)
             raise("The graphite url should be either http or https") unless ["http", "https"].include?(@uri.scheme)
+          end
+
+          def to_execution_result(results)
+            webhook_task.to_execution_result(results)
           end
 
           def from_hash(properties)

--- a/lib/mcollective/util/playbook/tasks/shell_task.rb
+++ b/lib/mcollective/util/playbook/tasks/shell_task.rb
@@ -33,6 +33,19 @@ module MCollective
             options
           end
 
+          def to_execution_result(results)
+            result = {
+              "value" => results[2].join("\r\n").chomp,
+              "error" => {
+                "msg" => results[1]
+              }
+            }
+
+            result.delete("error") if results[0]
+
+            {"localhost" => result}
+          end
+
           def run
             if @nodes
               Log.info("Starting command %s against %d nodes" % [@command, @nodes.size])

--- a/lib/mcollective/util/playbook/tasks/slack_task.rb
+++ b/lib/mcollective/util/playbook/tasks/slack_task.rb
@@ -50,6 +50,17 @@ module MCollective
             ]
           end
 
+          def to_execution_result(results)
+            result = {"value" => results[1]}
+
+            unless results[0]
+              result["error"] = {"msg" => results[1]}
+              result["value"] = results[2].first
+            end
+
+            {"slack.com" => result}
+          end
+
           def run
             https = choria.https(:target => "slack.com", :port => 443)
             path = "/api/chat.postMessage?token=%s&username=%s&channel=%s&icon_url=%s&attachments=%s" % [

--- a/lib/mcollective/util/playbook/tasks/webhook_task.rb
+++ b/lib/mcollective/util/playbook/tasks/webhook_task.rb
@@ -88,6 +88,19 @@ module MCollective
             http
           end
 
+          def to_execution_result(results)
+            result = {
+              "value" => results[2].first,
+              "error" => {
+                "msg" => results[1]
+              }
+            }
+
+            result.delete("error") if results[0]
+
+            {create_uri.host => result}
+          end
+
           def run
             uri = create_uri
             resp = http(uri).request(http_request(uri))

--- a/module/data/plugin.yaml
+++ b/module/data/plugin.yaml
@@ -17,6 +17,9 @@ mcollective_choria::client_files:
  - application/playbook.rb
  - discovery/choria.ddl
  - discovery/choria.rb
+ - util/bolt_support.rb
+ - util/playbook.rb
+ - util/playbook/data_stores.rb
  - util/playbook/data_stores/base.rb
  - util/playbook/data_stores/consul_data_store.rb
  - util/playbook/data_stores/environment_data_store.rb
@@ -24,25 +27,23 @@ mcollective_choria::client_files:
  - util/playbook/data_stores/file_data_store.rb
  - util/playbook/data_stores/memory_data_store.rb
  - util/playbook/data_stores/shell_data_store.rb
- - util/playbook/data_stores.rb
  - util/playbook/inputs.rb
+ - util/playbook/nodes.rb
  - util/playbook/nodes/mcollective_nodes.rb
  - util/playbook/nodes/pql_nodes.rb
- - util/playbook/nodes.rb
  - util/playbook/nodes/shell_nodes.rb
  - util/playbook/nodes/terraform_nodes.rb
  - util/playbook/nodes/yaml_nodes.rb
  - util/playbook/playbook_logger.rb
- - util/playbook.rb
  - util/playbook/report.rb
  - util/playbook/task_result.rb
+ - util/playbook/tasks.rb
  - util/playbook/tasks/base.rb
- - util/playbook/tasks/data_task.rb
  - util/playbook/tasks/bolt_task.rb
+ - util/playbook/tasks/data_task.rb
  - util/playbook/tasks/graphite_event_task.rb
  - util/playbook/tasks/mcollective_assert_task.rb
  - util/playbook/tasks/mcollective_task.rb
- - util/playbook/tasks.rb
  - util/playbook/tasks/shell_task.rb
  - util/playbook/tasks/slack_task.rb
  - util/playbook/tasks/webhook_task.rb

--- a/module/lib/puppet/functions/choria_data.rb
+++ b/module/lib/puppet/functions/choria_data.rb
@@ -1,0 +1,65 @@
+# Read or write data from a Choria Playbook Data Store
+#
+# Any Data Store supported by Choria Playbooks is supported except the `memory`
+# one as there is no shared memory space between these function invocations
+#
+# @example writing data
+#
+# ~~~ puppet
+# # $data will be "1.2.3" and the value will be stored
+# # in the yaml file which would be created if not existing
+# $data = choria_data("version", "1.2.3",
+#    "type" => "file",
+#    "file" => "~/.plan.rc",
+#    "format" => "yaml",
+#    "create" => true
+# )`
+# ~~~
+#
+# @example reading data
+#
+# ~~~ puppet
+# # if ran after the previous example $data will equal "1.2.3"
+# $data = choria_data("version",
+#    "type" => "file",
+#    "file" => "~/.plan.rc",
+#    "format" => "yaml"
+# )
+# ~~
+#
+# The properties passed to the function is identical to those documents
+# in the [Choria Playbook Documentation](https://choria.io/docs/playbooks/data/).
+Puppet::Functions.create_function(:choria_data) do
+  dispatch :read do
+    param "String", :item
+    param "Hash", :properties
+  end
+
+  dispatch :write do
+    param "String", :item
+    param "String", :value
+    param "Hash", :properties
+  end
+
+  def init
+    # until bolt is not vendoring puppet
+    ["/opt/puppetlabs/mcollective/plugins", "C:/ProgramData/PuppetLabs/mcollective/plugins"].each do |libdir|
+      next if $LOAD_PATH.include?(libdir)
+      next unless File.directory?(libdir)
+
+      $LOAD_PATH << libdir
+    end
+
+    require "mcollective/util/bolt_support"
+
+    MCollective::Util::BoltSupport.init_choria
+  end
+
+  def read(item, properties)
+    init.data_read(item, properties)
+  end
+
+  def write(item, value, properties)
+    init.data_write(item, value, properties)
+  end
+end

--- a/module/lib/puppet/functions/choria_discover.rb
+++ b/module/lib/puppet/functions/choria_discover.rb
@@ -1,0 +1,79 @@
+# Discovers nodes using Choria Playbook Node Seets
+#
+# Any Node Set that Choria Playbooks support can be used
+# to discover nodes, test their Choria availability and
+# audit their agents
+#
+# @example discover using mcollective
+#
+# ~~~ puppet
+# # Discovers machines using apache in the UK
+# # test their reachability over mcollective and
+# # ensure they have the puppet agent is newer than
+# # version 1.2.3
+# $nodes = choria_discover("mcollective",
+#   "classes" => ["apache"],
+#   "facts" => ["country=uk"],
+#   "test" => true,
+#   "uses" => ["puppet" => ">= 1.2.3"]
+# )
+# ~~~
+#
+# @example discover using terraform outputs
+#
+# ~~~ puppet
+# $nodes = choria_discover("terraform",
+#   "statefile" => "/path/to/terraform.tfstate",
+#   "output" => "webservers"
+# )
+# ~~~
+#
+# @example perform PQL queries
+#
+# ~~~ puppet
+# $nodes = choria_discover("pql",
+#    "query" => "facts { name = 'country' and value = '${country}' }"
+# )
+# ~~~
+#
+# @example mcollective discovery shortcut
+#
+# ~~~ puppet
+# # On the assumption that mcollective discovery will be
+# # used most there is a shortcut
+# $nodes = choria_discover(
+#   "classes" => ["apache"],
+#   "facts" => ["country=uk"],
+#   "test" => true,
+#   "uses" => ["puppet" => ">= 1.2.3"]
+# )
+# ~~~
+Puppet::Functions.create_function(:choria_discover) do
+  dispatch :mcollective_discover do
+    param "Hash", :options
+  end
+
+  dispatch :discover do
+    param "String", :type
+    param "Hash", :options
+  end
+
+  def mcollective_discover(options)
+    discover("mcollective", options)
+  end
+
+  def discover(type, options)
+    # until bolt is not vendoring puppet
+    ["/opt/puppetlabs/mcollective/plugins", "C:/ProgramData/PuppetLabs/mcollective/plugins"].each do |libdir|
+      next if $LOAD_PATH.include?(libdir)
+      next unless File.directory?(libdir)
+
+      $LOAD_PATH << libdir
+    end
+
+    require "mcollective/util/bolt_support"
+
+    MCollective::Util::BoltSupport.init_choria.discover_nodes(type, options)
+  end
+end
+

--- a/module/lib/puppet/functions/choria_lock.rb
+++ b/module/lib/puppet/functions/choria_lock.rb
@@ -1,0 +1,48 @@
+# Runs a block of Puppet code within a Choria Data Store Lock
+#
+# This requires that you have a lockable data store, something like
+# consul or etcd
+#
+# @example run a set of exclusive tasks
+#
+# ~~~ puppet
+# $ds = {
+#   "type" => "consul",
+#   "timeout" => 120,
+#   "ttl" => 60
+# }
+#
+# # the code will only execute if the lock is acquired, this way multiple plans
+# # and choria playbooks and indeed anything that can talk to consul across your
+# # entire team can avoid running critical tasks at the same time to avoid corruption
+# # or concurrent modification related failures
+# choria_lock("acme_upgrade", $ds) || {
+#   upload_file("/srv/artifacts/acme-${version}.tgz", "/tmp/acme-${version}.tgz", $servers)
+#
+#   choria_task(
+#     "action" => "acme.upgrade",
+#     "nodes" => $servers
+#   )
+# }
+# ~~~
+Puppet::Functions.create_function(:choria_lock) do
+  dispatch :lock do
+    param "String", :item
+    param "Hash", :properties
+    block_param "Callable", :block
+  end
+
+  def lock(item, properties, &blk)
+    # until bolt is not vendoring puppet
+    ["/opt/puppetlabs/mcollective/plugins", "C:/ProgramData/PuppetLabs/mcollective/plugins"].each do |libdir|
+      next if $LOAD_PATH.include?(libdir)
+      next unless File.directory?(libdir)
+
+      $LOAD_PATH << libdir
+    end
+
+    require "mcollective/util/bolt_support"
+
+    MCollective::Util::BoltSupport.init_choria.data_lock(item, properties, &blk)
+  end
+end

--- a/module/lib/puppet/functions/choria_task.rb
+++ b/module/lib/puppet/functions/choria_task.rb
@@ -1,0 +1,67 @@
+# Execute Choria Playbook Tasks
+#
+# Any task supported by Choria Playbooks is supported and
+# can be used from within a plan, though there is probably
+# not much sense in using the Bolt task type as you can just
+# use `run_task` or `run_command` directly in the plan.
+#
+# The options to Playbook tasks like `pre_book`, `on_success`,
+# `on_fail` and `post_book` does not make sense within the
+# Puppet Plan DSL.
+#
+# @example disables puppet and wait for all nodes to idle
+#
+# ~~~ puppet
+# choria_task("mcollective",
+#   "action" => "puppet.disable",
+#   "nodes" => $all_nodes,
+#   "properties" => {
+#     "message" => "disabled during plan execution ${name}"
+#   }
+# )
+#
+# $result = choria_task("mcollective",
+#   "action" => "puppet.status",
+#   "nodes" => $all_nodes,
+#   "assert" => "idling=true",
+#   "tries" => 10,
+#   "try_sleep" => 30
+# )
+#
+# if $result.ok {
+#   choria_task("slack",
+#     "token" => $slack_token,
+#     "channel" = "#ops",
+#     "text" => "All nodes have been disabled and are idling"
+#   )
+# }
+# ~~~
+Puppet::Functions.create_function(:choria_task) do
+  dispatch :run_task do
+    param "String", :type
+    param "Hash", :properties
+  end
+
+  dispatch :run_mcollective_task do
+    param "Hash", :properties
+  end
+
+  def run_mcollective_task(properties)
+    run_task("mcollective", properties)
+  end
+
+  def run_task(type, properties)
+    # until bolt is not vendoring puppet
+    ["/opt/puppetlabs/mcollective/plugins", "C:/ProgramData/PuppetLabs/mcollective/plugins"].each do |libdir|
+      next if $LOAD_PATH.include?(libdir)
+      next unless File.directory?(libdir)
+
+      $LOAD_PATH << libdir
+    end
+
+    require "mcollective/util/bolt_support"
+
+    results = MCollective::Util::BoltSupport.init_choria.run_task(type, properties)
+    Puppet::Pops::Types::ExecutionResult.new(results)
+  end
+end

--- a/spec/fixtures/playbooks/file_data.yaml
+++ b/spec/fixtures/playbooks/file_data.yaml
@@ -1,0 +1,1 @@
+hello: world

--- a/spec/unit/mcollective/util/bolt_support_spec.rb
+++ b/spec/unit/mcollective/util/bolt_support_spec.rb
@@ -1,0 +1,138 @@
+require "spec_helper"
+require "mcollective/util/bolt_support"
+require "puppet"
+require "diplomat"
+
+module MCollective
+  module Util
+    describe BoltSupport do
+      let(:playbook) { Playbook.new("error") }
+      let(:support) { BoltSupport.new }
+
+      before(:each) do
+        Log.stubs(:error)
+        support.stubs(:playbook).returns(playbook)
+      end
+
+      describe "#data_lock" do
+        it "should lock and release" do
+          playbook.data_stores.stubs(:prepare)
+          playbook.data_stores.expects(:lock).with("plan_store/rspec").twice
+          playbook.data_stores.expects(:release).with("plan_store/rspec").twice
+
+          expect do
+            support.data_lock("rspec", "type" => "consul") { raise("rspec failure") }
+          end.to raise_error("rspec failure")
+
+          expect(support.data_lock("rspec", "type" => "consul") { "rspec result" }).to eq("rspec result")
+        end
+      end
+
+      describe "#run_task" do
+        it "should invoke the tasks and return an execution_result" do
+          result = support.run_task("shell", "command" => "/bin/echo 'hello world'")
+
+          expect(result).to eq(
+            "localhost" => {
+              "value" => "hello world"
+            }
+          )
+        end
+
+        it "should support fail_ok" do
+          expect { support.run_task("shell", "command" => "/bin/false") }.to raise_error(
+            "Command failed with code 1"
+          )
+
+          result = support.run_task("shell", "command" => "/bin/false", "fail_ok" => true)
+
+          expect(result).to eq(
+            "localhost" => {
+              "value" => "",
+              "error" => {
+                "msg" => "Command failed with code 1"
+              }
+            }
+          )
+        end
+      end
+
+      describe ".loglevel" do
+        it "should convert correctly" do
+          [
+            [:notice, "warn"],
+            [:warning, "warn"],
+            [:err, "error"],
+            [:alert, "fatal"],
+            [:emerg, "fatal"],
+            [:crit, "fatal"]
+          ].each do |p, m|
+            Puppet::Util::Log.stubs(:level).returns(p)
+            expect(BoltSupport.loglevel).to eq(m)
+          end
+        end
+      end
+
+      describe "#data_write" do
+        it "should write the right data" do
+          tf = Tempfile.new("rspec")
+          r = support.data_write("hello", "world",
+                                 "type" => "file",
+                                 "format" => "yaml",
+                                 "file" => tf.path)
+
+          expect(r).to eq("world")
+          expect(YAML.safe_load(File.read(tf.path))).to eq("hello" => "world")
+          tf.unlink
+        end
+      end
+
+      describe "#data_read" do
+        it "should read the right data" do
+          r = support.data_read("hello",
+                                "type" => "file",
+                                "format" => "yaml",
+                                "file" => File.expand_path("spec/fixtures/playbooks/file_data.yaml"))
+
+          expect(r).to eq("world")
+        end
+      end
+
+      describe "#discover_nodes" do
+        it "should support requests without uses" do
+          playbook.stubs(:uses).returns(u = stub)
+          u.expects(:from_hash).with({})
+
+          result = support.discover_nodes("yaml",
+                                          "source" => File.expand_path("spec/fixtures/playbooks/nodes.yaml"),
+                                          "group" => "uk")
+
+          expect(result).to eq(["node1.example.net", "node2.example.net", "node3.example.net"])
+        end
+
+        it "should support requests with uses" do
+          playbook.stubs(:uses).returns(u = stub)
+          u.expects(:from_hash).with("rpcutil" => "1.2.3")
+          support.stubs(:nodes).returns(n = stub)
+          n.expects(:from_hash).with(
+            "task_nodes" => {
+              "source" => File.expand_path("spec/fixtures/playbooks/nodes.yaml"),
+              "group" => "uk",
+              "type" => "yaml",
+              "uses" => ["rpcutil"]
+            }
+          )
+          n.expects(:prepare)
+          n.expects(:[]).with("task_nodes").returns(["n1"])
+
+          result = support.discover_nodes("yaml",
+                                          "source" => File.expand_path("spec/fixtures/playbooks/nodes.yaml"),
+                                          "group" => "uk",
+                                          "uses" => {"rpcutil" => "1.2.3"})
+
+          expect(result).to eq(["n1"])
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/util/playbook/nodes/mcollective_nodes_spec.rb
+++ b/spec/unit/mcollective/util/playbook/nodes/mcollective_nodes_spec.rb
@@ -11,7 +11,7 @@ module MCollective
           describe "#create_and_configure_client" do
             it "should configure a client" do
               Util.stubs(:config_file_for_user).returns("/nonexisting/client.cfg")
-              RPC::Client.expects(:new).with("r_agent", :configfile => "/nonexisting/client.cfg").returns(c = stub)
+              RPC::Client.expects(:new).with("r_agent", :configfile => "/nonexisting/client.cfg", :options => Util.default_options).returns(c = stub)
 
               c.expects(:progress=).with(false)
               c.expects(:discovery_method=).with("rspec_dm")

--- a/spec/unit/mcollective/util/playbook/tasks/bolt_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/bolt_task_spec.rb
@@ -13,6 +13,12 @@ module MCollective
             task.stubs(:bolt_executor).returns(executor)
           end
 
+          describe "#to_execution_result" do
+            it "should return the result unmodified" do
+              expect(task.to_execution_result([true, "test", {"result" => "rspec"}])).to eq("result" => "rspec")
+            end
+          end
+
           describe "#run" do
             it "should run tasks" do
               task.stubs(:current_time).returns(Time.now - 1)

--- a/spec/unit/mcollective/util/playbook/tasks/data_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/data_task_spec.rb
@@ -10,6 +10,26 @@ module MCollective
           let(:playbook) { stub(:data_stores => ds) }
           let(:task) { DataTask.new(playbook) }
 
+          describe "#to_execution_result" do
+            it "should support success results" do
+              expect(task.to_execution_result([true, "Wrote value to store/y", ["x"]])).to eq(
+                "localhost" => {
+                  "value" => "x"
+                }
+              )
+            end
+
+            it "should support error results" do
+              expect(task.to_execution_result([false, "Unknown action foo", []])).to eq(
+                "localhost" => {
+                  "error" => {
+                    "msg" => "Unknown action foo"
+                  }
+                }
+              )
+            end
+          end
+
           describe "#run" do
             it "should support writing" do
               task.from_hash("action" => "write", "key" => "store/y", "value" => "x")

--- a/spec/unit/mcollective/util/playbook/tasks/graphite_event_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/graphite_event_task_spec.rb
@@ -8,6 +8,17 @@ module MCollective
         describe Graphite_eventTask do
           let(:task) { Graphite_eventTask.new(stub) }
 
+          describe "#to_execution_result" do
+            it "should delegate onto the webhook task" do
+              task.expects(:webhook_task).returns(wh = stub)
+
+              results = [true, "success", []]
+              wh.expects(:to_execution_result).with(results).returns(er = stub)
+
+              expect(task.to_execution_result(results)).to be(er)
+            end
+          end
+
           describe "#run" do
             it "should run the webhook" do
               task.expects(:webhook_task).returns(wh = stub)

--- a/spec/unit/mcollective/util/playbook/tasks/shell_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/shell_task_spec.rb
@@ -8,6 +8,27 @@ module MCollective
         describe ShellTask do
           let(:task) { ShellTask.new(stub) }
 
+          describe "#to_execution_result" do
+            it "should support success" do
+              expect(task.to_execution_result([true, "Command completed successfully", ["stdout"]])).to eq(
+                "localhost" => {
+                  "value" => "stdout"
+                }
+              )
+            end
+
+            it "should support errors" do
+              expect(task.to_execution_result([false, "Command failed with code 1", ["stdout"]])).to eq(
+                "localhost" => {
+                  "value" => "stdout",
+                  "error" => {
+                    "msg" => "Command failed with code 1"
+                  }
+                }
+              )
+            end
+          end
+
           describe "#run" do
             it "should detect failed scripts" do
               task.from_hash("command" => "/tmp/x.sh")

--- a/spec/unit/mcollective/util/playbook/tasks/slack_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/slack_task_spec.rb
@@ -13,6 +13,27 @@ module MCollective
             PluginManager.stubs(:[]).with("security_plugin").returns(stub(:callerid => "choria=rspec"))
           end
 
+          describe "#to_execution_result" do
+            it "should support success" do
+              expect(task.to_execution_result([true, "Message submitted to slack channel rspec", [{}]])).to eq(
+                "slack.com" => {
+                  "value" => "Message submitted to slack channel rspec"
+                }
+              )
+            end
+
+            it "should support failure" do
+              expect(task.to_execution_result([false, "Failed to send message to slack channel X: xx", [{"rspec" => "failed"}]])).to eq(
+                "slack.com" => {
+                  "value" => {"rspec" => "failed"},
+                  "error" => {
+                    "msg" => "Failed to send message to slack channel X: xx"
+                  }
+                }
+              )
+            end
+          end
+
           describe "#attachments" do
             before(:each) do
               task.from_hash(

--- a/spec/unit/mcollective/util/playbook/tasks/webhook_task_spec.rb
+++ b/spec/unit/mcollective/util/playbook/tasks/webhook_task_spec.rb
@@ -20,6 +20,38 @@ module MCollective
             )
           end
 
+          describe "#to_execution_result" do
+            it "should support success" do
+              r = [
+                true,
+                "Successfully sent POST request to webhook http://localhost/rspec?foo=bar with id 479d1982-120a-5ba8-8664-1f16a6504371",
+                ["ok"]
+              ]
+
+              expect(task.to_execution_result(r)).to eq(
+                "localhost" => {
+                  "value" => "ok"
+                }
+              )
+            end
+
+            it "should support failure" do
+              r = [
+                false,
+                "Failed to send POST request to webhook http://localhost/rspec?foo=bar with id 479d1982-120a-5ba8-8664-1f16a6504371: 404: not found", ["not found"]
+              ]
+
+              expect(task.to_execution_result(r)).to eq(
+                "localhost" => {
+                  "value" => "not found",
+                  "error" => {
+                    "msg" => "Failed to send POST request to webhook http://localhost/rspec?foo=bar with id 479d1982-120a-5ba8-8664-1f16a6504371: 404: not found"
+                  }
+                }
+              )
+            end
+          end
+
           describe "#http" do
             it "should support https requests with and without SSL verification" do
               http = task.http(URI("https://localhost"))


### PR DESCRIPTION
This creates 3 functions that expose Playbook tasks, data and discovery
to the Puppet Plan DSL - choria_data(), choria_discover() and
choria_task()

In order to achieve that the task results have to be transformed into a
format that the Puppet ExecutionResult understands so each task got
added a to_execution_result method that can turn its standard format
result into one passable to Puppet

A BoltSupport class have been added used by all the functions as a
helper to perform their functions

Closes #348, #353 