### PR TITLE
(#347) bolt_task agent with download actions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     CFPropertyList (2.3.5)
     addressable (2.4.0)
     ast (2.3.0)
-    bolt (0.6.1)
+    bolt (0.7.0)
       CFPropertyList (~> 2.2)
       addressable (< 2.5.0)
       concurrent-ruby (~> 1.0)
@@ -107,7 +107,7 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     lumberjack (1.0.12)
-    mcollective-client (2.11.3)
+    mcollective-client (2.11.4)
       json
       stomp
       systemu
@@ -137,7 +137,7 @@ GEM
     pry (0.11.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    puppet (5.3.2)
+    puppet (5.3.3)
       facter (> 2.0, < 4)
       gettext-setup (>= 0.10, < 1)
       hiera (>= 3.2.1, < 4)
@@ -192,7 +192,7 @@ GEM
       tins (~> 1.0)
     text (1.3.1)
     thor (0.19.4)
-    tins (1.15.0)
+    tins (1.15.1)
     unicode-display_width (1.3.0)
     webmock (3.1.0)
       addressable (>= 2.3.6)

--- a/Rakefile
+++ b/Rakefile
@@ -67,7 +67,7 @@ task :release do
   sh("cp CHANGELOG.md LICENSE.txt module")
   sh("cp .gitignore module")
   Dir.chdir("module") do
-    sh("/opt/puppetlabs/bin/puppet module build")
+    sh("/usr/bin/env -i PATH=/bin:/usr/bin bash -e /opt/puppetlabs/bin/puppet module build")
   end
   sh("rm -rf module/files/mcollective/*")
 end

--- a/lib/mcollective/agent/bolt_task.ddl
+++ b/lib/mcollective/agent/bolt_task.ddl
@@ -1,0 +1,41 @@
+metadata :name => "bolt_task",
+         :description => "Downloads and runs Puppet Bolt tasks",
+         :author => "R.I.Pienaar <rip@devco.net>",
+         :license => "Apache-2.0",
+         :version => "0.0.1",
+         :url => "https://choria.io",
+         :timeout => 60
+
+requires :mcollective => "2.11.0"
+
+action "download", :description => "Downloads a Bolt task into a local cache" do
+  input :task,
+        :prompt      => "Task Name",
+        :description => "The name of a task, example apache or apache::reload",
+        :type        => :string,
+        :validation  => '\A([a-z][a-z0-9_]*)?(::[a-z][a-z0-9_]*)*\Z',
+        :optional    => false,
+        :maxlength   => 100
+
+  input :environment,
+        :prompt      => "Puppet Environment",
+        :description => "The environment the task should be fetched from",
+        :type        => :string,
+        :validation  => '\A[a-z][a-z0-9_]*\z',
+        :optional    => false,
+        :default     => "production",
+        :maxlength   => 100
+
+  input :files,
+        :prompt      => "Task Files Specification",
+        :description => "The specification of files to download according to v3 api in JSON format",
+        :type        => :string,
+        :optional    => true,
+        :validation  => '\A\[.+\]\z',
+        :maxlength   => 2000,
+        :default     => "[]"
+
+  output :downloads,
+         :description => "The number of files downloaded",
+         :display_as  => "Files Downloaded"
+end

--- a/lib/mcollective/agent/bolt_task.rb
+++ b/lib/mcollective/agent/bolt_task.rb
@@ -1,0 +1,29 @@
+require "mcollective/util/choria"
+require "mcollective/util/tasks_support"
+
+module MCollective
+  module Agent
+    class Bolt_task < RPC::Agent
+      action "download" do
+        tasks = Util::Choria.new.tasks_support
+
+        meta = tasks.task_metadata(request[:task], request[:environment])
+
+        reply.fail!("Did not receive valid metadata from Puppet Server for task %s" % request[:task]) if meta.empty?
+
+        if request[:files] && !request[:files] == "[]"
+          reply.fail!("Received different file specification from Puppet than requested") unless meta["files"] == JSON.parse(request[:files])
+        else
+          Log.warn("Downloading bolt task %s without a file specification" % [request[:task]])
+        end
+
+        if tasks.download_task(meta)
+          reply[:downloads] = meta["files"].size
+        else
+          reply[:downloads] = 0
+          reply.fail!("Could not download task %s files: %s" % [request[:task], $!.to_s])
+        end
+      end
+    end
+  end
+end

--- a/lib/mcollective/agent/choria_util.ddl
+++ b/lib/mcollective/agent/choria_util.ddl
@@ -3,7 +3,7 @@ metadata    :name        => "choria_util",
             :author      => "R.I.Pienaar <rip@devco.net>",
             :license     => "Apache-2.0",
             :version     => "0.4.0",
-            :url         => "http:/choria.io",
+            :url         => "https://choria.io",
             :timeout     => 5
 
 requires :mcollective => "2.9.0"

--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -19,6 +19,28 @@ module MCollective
         check_ssl_setup if check_ssl
       end
 
+      # Creates a new TasksSupport instance with the configured cache dir
+      #
+      # @return [TasksSupport]
+      def tasks_support
+        require_relative "tasks_support"
+
+        Util::TasksSupport.new(self, tasks_cache_dir)
+      end
+
+      # Determines the Tasks Cache dir
+      #
+      # @return [String] path to the cache
+      def tasks_cache_dir
+        if Util.windows?
+          File.join(Util.windows_prefix, "tasks-cache")
+        elsif Process.uid == 0
+          "/opt/puppetlabs/mcollective/tasks-cache"
+        else
+          File.expand_path("~/.puppetlabs/mcollective/tasks-cache")
+        end
+      end
+
       # Factory for Federation Brokers
       #
       # We do it here to avoid always requiring all the federation broker code

--- a/lib/mcollective/util/playbook/tasks/bolt_task.rb
+++ b/lib/mcollective/util/playbook/tasks/bolt_task.rb
@@ -52,7 +52,7 @@ module MCollective
               uri = node
               uri = "%s://%s" % [@transport, node] unless @transport == "ssh" || uri =~ /^(winrm|ssh):\/\/(.+)/
 
-              Bolt::Node.from_uri(uri)
+              Bolt::Node.from_uri(uri, :config => bolt_cli.config)
             end
           end
 
@@ -72,22 +72,24 @@ module MCollective
           def bolt_cli
             return @__cli if @__cli
 
+            @__cli = Bolt::CLI.new({})
+
             # We would rather pass a configured logger into bolt, see
             # https://github.com/puppetlabs/bolt/issues/79
             case @playbook.loglevel
             when "fatal"
-              Bolt.log_level = ::Logger::FATAL
+              @__cli.config[:log_level] = ::Logger::FATAL
             when "error"
-              Bolt.log_level = ::Logger::ERROR
+              @__cli.config[:log_level] = ::Logger::ERROR
             when "warn"
-              Bolt.log_level = ::Logger::WARN
+              @__cli.config[:log_level] = ::Logger::WARN
             when "debug"
-              Bolt.log_level = ::Logger::DEBUG
+              @__cli.config[:log_level] = ::Logger::DEBUG
             else
-              Bolt.log_level = ::Logger::INFO
+              @__cli.config[:log_level] = ::Logger::INFO
             end
 
-            @__cli = Bolt::CLI.new({})
+            @__cli
           end
 
           def bolt_executor
@@ -103,7 +105,7 @@ module MCollective
             input_method = nil
 
             unless File.exist?(path)
-              path, metadata = bolt_cli.load_task_data(path, @modules)
+              path, metadata = bolt_cli.load_task_data(path, Array(@modules))
               input_method = metadata["input_method"]
             end
 

--- a/module/data/plugin.yaml
+++ b/module/data/plugin.yaml
@@ -9,6 +9,7 @@ mcollective_choria::client_directories:
  - util/playbook/nodes
  - util/playbook/tasks
 mcollective_choria::server_files:
+ - agent/bolt_task.rb
  - agent/choria_util.rb
  - audit/choria.rb
  - registration/choria.rb
@@ -52,6 +53,7 @@ mcollective_choria::common_directories:
  - util/choria
  - util/federation_broker
 mcollective_choria::common_files:
+ - agent/bolt_task.ddl
  - application/federation.rb
  - agent/choria_util.ddl
  - connector/nats.ddl
@@ -64,3 +66,4 @@ mcollective_choria::common_files:
  - util/federation_broker/stats.rb
  - util/choria.rb
  - util/natswrapper.rb
+ - util/tasks_support.rb

--- a/spec/fixtures/tasks/tasks_list.json
+++ b/spec/fixtures/tasks/tasks_list.json
@@ -1,0 +1,1 @@
+[{"name":"choria::ls","environment":[{"name":"production","code_id":null}]},{"name":"puppet_conf","environment":[{"name":"production","code_id":null}]}]

--- a/spec/unit/mcollective/util/choria_spec.rb
+++ b/spec/unit/mcollective/util/choria_spec.rb
@@ -6,6 +6,32 @@ module MCollective
     describe Choria do
       let(:choria) { Choria.new(false) }
 
+      describe "#tasks_cache_dir" do
+        it "should support windows" do
+          Util.stubs(:windows?).returns(true)
+          Util.stubs(:windows_prefix).returns("c:/nonexisting")
+
+          expect(choria.tasks_cache_dir).to eq("c:/nonexisting/tasks-cache")
+        end
+
+        it "should support root users" do
+          Process.stubs(:uid).returns(0)
+          expect(choria.tasks_cache_dir).to eq("/opt/puppetlabs/mcollective/tasks-cache")
+        end
+
+        it "should support non root users" do
+          expect(choria.tasks_cache_dir).to eq(File.expand_path("~/.puppetlabs/mcollective/tasks-cache"))
+        end
+      end
+
+      describe "#tasks_support" do
+        it "should create a support object that's correctly configured" do
+          choria.stubs(:tasks_cache_dir).returns("/nonexisting/tasks-cache")
+          support = choria.tasks_support
+          expect(support.cache_dir).to eq("/nonexisting/tasks-cache")
+        end
+      end
+
       describe "#proxied_discovery?" do
         it "should correctly detect if proxied" do
           expect(choria.proxied_discovery?).to be(false)


### PR DESCRIPTION
This adds a bolt_task agent that for now have just a download action
which can fetch and cache any bolt task

It can be given a file spec obtained from the server API and passed
along thus ensuring all the nodes get the same code, it's optional
though since its impossible to type on the cli - but the canonical use
case would be to use it via a as yet non existing UI

Also some other bits like obtain a list of tasks etc