### PR TITLE
(#347) Adds run and status actions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -161,3 +161,5 @@ Style/SafeNavigation:
 Lint/RescueWithoutErrorClass:
   Enabled: false
 
+Performance/StringReplacement:
+  Enabled: false

--- a/lib/mcollective/agent/bolt_task.ddl
+++ b/lib/mcollective/agent/bolt_task.ddl
@@ -13,7 +13,7 @@ action "download", :description => "Downloads a Bolt task into a local cache" do
         :prompt      => "Task Name",
         :description => "The name of a task, example apache or apache::reload",
         :type        => :string,
-        :validation  => '\A([a-z][a-z0-9_]*)?(::[a-z][a-z0-9_]*)*\Z',
+        :validation  => :bolt_task_name,
         :optional    => false,
         :maxlength   => 100
 
@@ -30,12 +30,173 @@ action "download", :description => "Downloads a Bolt task into a local cache" do
         :prompt      => "Task Files Specification",
         :description => "The specification of files to download according to v3 api in JSON format",
         :type        => :string,
-        :optional    => true,
+        :optional    => false,
         :validation  => '\A\[.+\]\z',
-        :maxlength   => 2000,
-        :default     => "[]"
+        :maxlength   => 4000
 
   output :downloads,
          :description => "The number of files downloaded",
          :display_as  => "Files Downloaded"
+end
+
+action "run_and_wait", :description => "Runs a Bolt ask that was previously downloaded, wait for it to finish" do
+  input :task,
+        :prompt      => "Task Name",
+        :description => "The name of a task, example apache or apache::reload",
+        :type        => :string,
+        :validation  => :bolt_task_name,
+        :optional    => false,
+        :maxlength   => 100
+
+  input :input_method,
+        :prompt      => "Input Method",
+        :description => "The input method to use",
+        :type        => :list,
+        :list        => ["powershell", "stdin", "environment", "both"],
+        :optional    => true,
+        :default     => nil
+
+  input :files,
+        :prompt      => "Task Files Specification",
+        :description => "The specification of files to download according to v3 api in JSON format",
+        :type        => :string,
+        :optional    => false,
+        :validation  => '\A\[.+\]\z',
+        :maxlength   => 4000
+
+  input :input,
+        :prompt      => "Task Input",
+        :description => "JSON String containing input variables",
+        :type        => :string,
+        :validation  => '^.+$',
+        :optional    => true,
+        :default     => "{}",
+        :maxlength   => 102400
+
+  output :task_id,
+         :description => "The ID the task was created with",
+         :display_as  => "Task ID",
+         :default     => nil
+
+  output :exitcode,
+         :description => "Task exit code",
+         :display_as  => "Exit Code",
+         :default     => 127
+
+  output :stdout,
+         :description => "Standard Output from the command",
+         :display_as  => "STDOUT",
+         :default     => nil
+
+  output :stderr,
+         :description => "Standard Error from the command",
+         :display_as  => "STDERR",
+         :default     => nil
+
+  output :completed,
+         :description => "Did the task complete",
+         :display_as  => "Completed",
+         :default     => false
+
+  output :runtime,
+         :description => "Time taken to run the command",
+         :display_as  => "Runtime",
+         :default     => 0
+
+  output :start_time,
+         :description => "When the task was started in UTC time",
+         :display_as  => "Start Time"
+
+  summarize do
+    aggregate average(:runtime)
+    aggregate summary(:exitcode)
+    aggregate summary(:completed)
+  end
+end
+
+action "run_no_wait", :description => "Runs a Bolt ask that was previously downloaded do not wait for it to finish" do
+  input :task,
+        :prompt      => "Task Name",
+        :description => "The name of a task, example apache or apache::reload",
+        :type        => :string,
+        :validation  => :bolt_task_name,
+        :optional    => false,
+        :maxlength   => 100
+
+  input :input_method,
+        :prompt      => "Input Method",
+        :description => "The input method to use",
+        :type        => :list,
+        :list        => ["powershell", "stdin", "environment", "both"],
+        :optional    => true,
+        :default     => nil
+
+  input :files,
+        :prompt      => "Task Files Specification",
+        :description => "The specification of files to download according to v3 api in JSON format",
+        :type        => :string,
+        :optional    => false,
+        :validation  => '\A\[.+\]\z',
+        :maxlength   => 4000
+
+  input :input,
+        :prompt      => "Task Input",
+        :description => "JSON String containing input variables",
+        :type        => :string,
+        :validation  => '^.+$',
+        :optional    => true,
+        :default     => "{}",
+        :maxlength   => 102400
+
+  output :task_id,
+         :description => "The ID the task was created with",
+         :display_as  => "Task ID",
+         :default     => nil
+end
+
+action "task_status", :description => "Request the status of a previously ran task" do
+  display :always
+
+  input :task_id,
+        :prompt      => "Task ID",
+        :description => "The Task ID to retrieve",
+        :type        => :string,
+        :validation  => '^[a-z,0-9]{32}$',
+        :optional    => false,
+        :maxlength   => 32
+
+  output :exitcode,
+         :description => "Task exit code",
+         :display_as  => "Exit Code",
+         :default     => 127
+
+  output :stdout,
+         :description => "Standard Output from the command",
+         :display_as  => "STDOUT",
+         :default     => nil
+
+  output :stderr,
+         :description => "Standard Error from the command",
+         :display_as  => "STDERR",
+         :default     => nil
+
+  output :completed,
+         :description => "Did the task complete",
+         :display_as  => "Completed",
+         :default     => false
+
+  output :runtime,
+         :description => "Time taken to run the command",
+         :display_as  => "Runtime",
+         :default     => 0
+
+  output :start_time,
+         :description => "When the task was started in UTC time",
+         :display_as  => "Start Time"
+
+  summarize do
+    aggregate average(:runtime)
+    aggregate summary(:exitcode)
+    aggregate summary(:completed)
+  end
 end

--- a/lib/mcollective/agent/bolt_task.rb
+++ b/lib/mcollective/agent/bolt_task.rb
@@ -10,12 +10,7 @@ module MCollective
         meta = tasks.task_metadata(request[:task], request[:environment])
 
         reply.fail!("Did not receive valid metadata from Puppet Server for task %s" % request[:task]) if meta.empty?
-
-        if request[:files] && !request[:files] == "[]"
-          reply.fail!("Received different file specification from Puppet than requested") unless meta["files"] == JSON.parse(request[:files])
-        else
-          Log.warn("Downloading bolt task %s without a file specification" % [request[:task]])
-        end
+        reply.fail!("Received different file specification from Puppet than requested") unless meta["files"] == JSON.parse(request[:files])
 
         if tasks.download_task(meta)
           reply[:downloads] = meta["files"].size
@@ -23,6 +18,64 @@ module MCollective
           reply[:downloads] = 0
           reply.fail!("Could not download task %s files: %s" % [request[:task], $!.to_s])
         end
+      end
+
+      action "run_and_wait" do
+        tasks = Util::Choria.new.tasks_support
+
+        reply[:task_id] = request.uniqid
+
+        task = {
+          "task" => request[:task],
+          "input_method" => request[:input_method],
+          "input" => request[:input],
+          "files" => JSON.parse(request[:files])
+        }
+
+        status = nil
+
+        # Wait for near the timeout and on timeout give up and fetch the
+        # status so users can get good replies that include how things are
+        # near timeout
+        begin
+          Timeout.timeout(timeout - 2) do
+            status = tasks.run_task_command(reply[:task_id], task)
+          end
+        rescue Timeout::Error
+          status = tasks.task_status(reply[:task_id])
+        ensure
+          reply_task_status(status) if status
+        end
+      end
+
+      action "run_no_wait" do
+        tasks = Util::Choria.new.tasks_support
+
+        reply[:task_id] = request.uniqid
+
+        task = {
+          "task" => request[:task],
+          "input_method" => request[:input_method],
+          "input" => request[:input],
+          "files" => JSON.parse(request[:files])
+        }
+
+        tasks.run_task_command(reply[:task_id], task)
+      end
+
+      action "task_status" do
+        tasks = Util::Choria.new.tasks_support
+
+        reply_task_status(tasks.task_status(request[:task_id]))
+      end
+
+      def reply_task_status(status)
+        reply[:exitcode] = status["exitcode"]
+        reply[:stdout] = status["stdout"]
+        reply[:stderr] = status["stderr"]
+        reply[:completed] = status["completed"]
+        reply[:runtime] = status["runtime"]
+        reply[:start_time] = status["start_time"]
       end
     end
   end

--- a/lib/mcollective/validator/bolt_task_name_validator.ddl
+++ b/lib/mcollective/validator/bolt_task_name_validator.ddl
@@ -1,0 +1,7 @@
+metadata    :name => "bolt_task_name",
+            :description => "Validates that a string matches Bolt Task Name",
+            :author => "R.I.Pienaar <rip@devco.net>",
+            :license => "Apache-2.0",
+            :version => "0.0.1",
+            :url => "https://choria.io",
+            :timeout => 1

--- a/lib/mcollective/validator/bolt_task_name_validator.rb
+++ b/lib/mcollective/validator/bolt_task_name_validator.rb
@@ -1,0 +1,11 @@
+module MCollective
+  module Validator
+    class Bolt_task_nameValidator
+      def self.validate(name)
+        Validator.typecheck(name, :string)
+
+        raise("'%s' is not a valid Bolt Task name" % name) unless name =~ /\A([a-z][a-z0-9_]*)?(::[a-z][a-z0-9_]*)*\Z/
+      end
+    end
+  end
+end

--- a/module/data/plugin.yaml
+++ b/module/data/plugin.yaml
@@ -67,3 +67,5 @@ mcollective_choria::common_files:
  - util/choria.rb
  - util/natswrapper.rb
  - util/tasks_support.rb
+ - validator/bolt_task_name_validator.rb
+ - validator/bolt_task_name_validator.ddl


### PR DESCRIPTION
This adds 3 actions, 2 for running and one status.

When running you can request a run and wait scenario where the agent
will wait till near the agent timeout for the command to finish, if it
has not finished yet by that time the then current status will be
returned.  When not waiting the request id is returned

Later status can be used with the requestid to gather status for any
task