### PR TITLE
(#347) Record who requested the task and what the task is

### DIFF
--- a/lib/mcollective/agent/bolt_task.ddl
+++ b/lib/mcollective/agent/bolt_task.ddl
@@ -82,6 +82,16 @@ action "run_and_wait", :description => "Runs a Bolt ask that was previously down
          :display_as  => "Task ID",
          :default     => nil
 
+  output :task,
+         :description => "Task name",
+         :display_as  => "Task",
+         :default     => nil
+
+  output :callerid,
+         :description => "User who initiated the task",
+         :display_as  => "User",
+         :default     => nil
+
   output :exitcode,
          :description => "Task exit code",
          :display_as  => "Exit Code",
@@ -113,6 +123,8 @@ action "run_and_wait", :description => "Runs a Bolt ask that was previously down
 
   summarize do
     aggregate average(:runtime)
+    aggregate summary(:task)
+    aggregate summary(:callerid)
     aggregate summary(:exitcode)
     aggregate summary(:completed)
     aggregate summary(:task_id)
@@ -174,6 +186,16 @@ action "task_status", :description => "Request the status of a previously ran ta
         :optional    => false,
         :maxlength   => 32
 
+  output :task,
+         :description => "Task name",
+         :display_as  => "Task",
+         :default     => nil
+
+  output :callerid,
+         :description => "User who initiated the task",
+         :display_as  => "User",
+         :default     => nil
+
   output :exitcode,
          :description => "Task exit code",
          :display_as  => "Exit Code",
@@ -205,6 +227,8 @@ action "task_status", :description => "Request the status of a previously ran ta
 
   summarize do
     aggregate average(:runtime)
+    aggregate summary(:task)
+    aggregate summary(:callerid)
     aggregate summary(:exitcode)
     aggregate summary(:completed)
   end

--- a/spec/fixtures/tasks/completed_spool/choria.json
+++ b/spec/fixtures/tasks/completed_spool/choria.json
@@ -1,0 +1,5 @@
+{
+  "start_time": 1510496922,
+  "caller": "choria=rip.mcollective",
+  "task": "choria::ls"
+}

--- a/spec/fixtures/tasks/still_running_spool/choria.json
+++ b/spec/fixtures/tasks/still_running_spool/choria.json
@@ -1,0 +1,5 @@
+{
+  "start_time": 1510496922,
+  "caller": "choria=rip.mcollective",
+  "task": "choria::ls"
+}

--- a/spec/fixtures/tasks/wrapper_failed_spool/choria.json
+++ b/spec/fixtures/tasks/wrapper_failed_spool/choria.json
@@ -1,0 +1,5 @@
+{
+  "start_time": 1510496922,
+  "caller": "choria=rip.mcollective",
+  "task": "choria::ls"
+}

--- a/spec/unit/mcollective/util/tasks_support_spec.rb
+++ b/spec/unit/mcollective/util/tasks_support_spec.rb
@@ -64,11 +64,13 @@ ERROR
             "stderr" => "",
             "exitcode" => 127,
             "runtime" => 0.0,
-            "start_time" => Time.at(0),
             "wrapper_spawned" => false,
             "wrapper_error" => err,
             "wrapper_pid" => nil,
-            "completed" => true
+            "completed" => true,
+            "task" => "choria::ls",
+            "caller" => "choria=rip.mcollective",
+            "start_time" => Time.at(1510496922).utc
           )
         end
 
@@ -85,11 +87,13 @@ ERROR
             "stderr" => "",
             "exitcode" => 127,
             "runtime" => 10,
-            "start_time" => File::Stat.new(File.join(spool, "wrapper_pid")).mtime,
             "wrapper_spawned" => true,
             "wrapper_error" => "",
             "wrapper_pid" => 2493,
-            "completed" => false
+            "completed" => false,
+            "task" => "choria::ls",
+            "caller" => "choria=rip.mcollective",
+            "start_time" => Time.at(1510496922).utc
           )
         end
 
@@ -109,11 +113,13 @@ ERROR
             "stderr" => "",
             "exitcode" => 0,
             "runtime" => 20.0,
-            "start_time" => File::Stat.new(File.join(spool, "wrapper_pid")).mtime,
             "wrapper_spawned" => true,
             "wrapper_error" => "",
             "wrapper_pid" => 2493,
-            "completed" => true
+            "completed" => true,
+            "task" => "choria::ls",
+            "caller" => "choria=rip.mcollective",
+            "start_time" => Time.at(1510496922).utc
           )
         end
       end


### PR DESCRIPTION
Use the recorded info to enhande status displays and add a metadata view
to the status action