### PR TITLE
(#347) Bolt Task AAA

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
 --color
---format doc

--- a/lib/mcollective/util/tasks_support.rb
+++ b/lib/mcollective/util/tasks_support.rb
@@ -457,6 +457,8 @@ module MCollective
       # @raise [StandardError] when the file does not exist
       def file_size(file_path)
         File.stat(file_path).size
+      rescue
+        -1
       end
 
       # Validates a task cache file


### PR DESCRIPTION
This does an additional authorization and audit when a task is being
run, it will set the action to the task name and call the authorization
and auditing plugins.

The end result is that you can authorize using any of the usual auth
stuff individual bolt tasks.  With action policy you can do:

    policy default deny

    # site wide policies
    allow *  run_and_wait run_no_wait download task_status * *
    allow choria=rip.mcollective  choria::ls  * *

this allows anyone to call the basic actions in the agent and then have
one specific task authorized - all other tasks are denied