### PR TITLE
(#347) Interpret _error correct according to spec

### DIFF
--- a/lib/mcollective/agent/bolt_task.ddl
+++ b/lib/mcollective/agent/bolt_task.ddl
@@ -73,7 +73,7 @@ action "run_and_wait", :description => "Runs a Bolt ask that was previously down
         :description => "JSON String containing input variables",
         :type        => :string,
         :validation  => '^.+$',
-        :optional    => true,
+        :optional    => false,
         :default     => "{}",
         :maxlength   => 102400
 


### PR DESCRIPTION
The spec specified that a key _error can be added on errors from the
task or runner, we now interpret that and set mcollective typical errors
based on that.

In non verbose output the data is shown without _error but in verbose
all the data is shown