### PR TITLE
(#347) Configurable ability to see tasks not requested by self

### DIFF
--- a/lib/mcollective/agent/bolt_task.rb
+++ b/lib/mcollective/agent/bolt_task.rb
@@ -105,11 +105,20 @@ module MCollective
           reply.fail!($!.to_s, 5)
         end
 
+        if caller_only_status? && request.caller != status["caller"]
+          reply[:stdout] = make_error($!.to_s, "choria/not_own_request", "taskid" => request[:task_id]).to_json
+          reply.fail!($!.to_s, 5)
+        end
+
         reply_task_status(status)
 
         if reply.statuscode == 0 && !status["wrapper_spawned"]
           reply.fail!("Could not spawn task %s: %s" % [request[:task], status["wrapper_error"]])
         end
+      end
+
+      def caller_only_status?
+        Util.str_to_bool(@config.pluginconf.fetch("choria.tasks.own_status_only", "true"))
       end
 
       def make_error(msg, kind, detail)


### PR DESCRIPTION
This allows choria.tasks.own_status_only to be set to false which would
let a user see outputs for tasks made by all others.  By default only
own