### PR TITLE
(#349) implement playbook run for plans

### DIFF
--- a/lib/mcollective/application/playbook.rb
+++ b/lib/mcollective/application/playbook.rb
@@ -8,10 +8,10 @@ module MCollective
 
   The ACTION can be one of the following:
 
-    show      - preview the playbook in parsed YAML format
     run       - run the playbook as your local user
 
-  The PLAYBOOK is a YAML file describing the tasks
+  The PLAYBOOK is a YAML file or Puppet Plan describing the
+  tasks
 
   Passing --help as well as a PLAYBOOK argument will show
   flags and help related to the specific playbook.
@@ -24,13 +24,39 @@ module MCollective
 
       exclude_argument_sections "common", "filter", "rpc"
 
-      # Parse out all options and look for any yaml|yml files in the remaining arguments
+      def pre_parse_modulepath
+        words = Shellwords.shellwords(ARGV.join(" "))
+        words.each_with_index do |word, idx|
+          if word == "--modulepath"
+            configuration[:__modulepath] = words[idx + 1]
+            break
+          end
+        end
+      end
+
+      # Playbook should be given right after the command, this finds the value after the command
       #
       # @return [String,nil]
-      def pre_parse_find_yaml
-        return ARGV.last if ARGV.last && ARGV.last =~ /\.(yaml|yml)/
+      def pre_parse_find_playbook
+        commands = Regexp.union(valid_commands)
 
-        ARGV.find {|a| a.match(/\.(yml|yaml)/)}
+        cmd_idx = ARGV.index {|a| a.match(commands)}
+        return nil unless cmd_idx
+
+        pb = ARGV[cmd_idx + 1]
+
+        pb if pb =~ Regexp.union(/(yaml|yml)\Z/, /\A([a-z][a-z0-9_]*)?(::[a-z][a-z0-9_]*)*\Z/)
+      end
+
+      # Determines the playbook type from its name
+      #
+      # @return [:yaml, :plan]
+      def playbook_type(playbook_name=nil)
+        playbook_name ||= configuration[:__playbook]
+
+        return :yaml if playbook_name =~ /(yml|yaml)$/
+
+        :plan
       end
 
       # Creates an instance of the playbook
@@ -38,47 +64,73 @@ module MCollective
       # @param file [String] path to a playbook yaml
       # @return [Util::Playbook]
       def playbook(file, loglevel=nil)
-        unless File.exist?(file)
-          raise("Cannot find supplied playbook file %s" % file)
-        end
+        if playbook_type(file) == :yaml
+          unless File.exist?(file)
+            raise("Cannot find supplied playbook file %s" % file)
+          end
 
-        Util.loadclass("MCollective::Util::Playbook")
-        playbook = Util::Playbook.new(loglevel)
-        playbook.from_hash(YAML.load_file(file))
-        playbook
+          Util.loadclass("MCollective::Util::Playbook")
+          playbook = Util::Playbook.new(loglevel)
+          playbook.from_hash(YAML.load_file(file))
+          playbook
+        else
+          require "mcollective/util/bolt_support"
+          runner = Util::BoltSupport::PlanRunner.new(
+            file,
+            configuration[:__tmpdir],
+            configuration[:__modulepath] || Dir.pwd,
+            configuration[:__loglevel] || "info"
+          )
+
+          raise("Cannot find supplied plan %s" % file) unless runner.exist?
+
+          runner
+        end
       end
 
       # Adds the playbook inputs as CLI options before starting the app
       def run
-        if playbook_file = pre_parse_find_yaml
-          configuration[:__playbook_file] = playbook_file
+        pre_parse_modulepath
 
-          if ARGV.include?("run")
-            playbook(playbook_file).add_cli_options(self, true)
-          else
-            playbook(playbook_file).add_cli_options(self, false)
+        Dir.mktmpdir("choria") do |dir|
+          configuration[:__tmpdir] = dir
+
+          if playbook_name = pre_parse_find_playbook
+            configuration[:__playbook] = playbook_name
+            playbook(playbook_name).add_cli_options(self, false)
           end
+
+          # Hackily done here to force it below the playbook options
+          self.class.option :__json_input,
+                            :arguments => ["--input INPUT"],
+                            :description => "JSON input to pass to the task",
+                            :required => false,
+                            :type => String
+
+          self.class.option :__modulepath,
+                            :arguments => ["--modulepath PATH"],
+                            :description => "Path to find Puppet module when using the Plan DSL",
+                            :type => String
+
+          self.class.option :__report,
+                            :arguments => ["--report"],
+                            :description => "Produce a report in YAML format",
+                            :default => false,
+                            :type => :boolean
+
+          self.class.option :__report_file,
+                            :arguments => ["--report-file FILE"],
+                            :description => "Override the default file name for the report",
+                            :type => String
+
+          self.class.option :__loglevel,
+                            :arguments => ["--loglevel LEVEL"],
+                            :description => "Override the loglevel set in the playbook (debug, info, warn, error, fatal)",
+                            :type => String,
+                            :validate => ->(level) { ["error", "fatal", "debug", "warn", "info"].include?(level) }
+
+          super
         end
-
-        # Hackily done here to force it below the playbook options
-        self.class.option :__report,
-                          :arguments => ["--report"],
-                          :description => "Produce a report in YAML format",
-                          :default => false,
-                          :type => :boolean
-
-        self.class.option :__report_file,
-                          :arguments => ["--report-file FILE"],
-                          :description => "Override the default file name for the report",
-                          :type => String
-
-        self.class.option :__loglevel,
-                          :arguments => ["--loglevel LEVEL"],
-                          :description => "Override the loglevel set in the playbook (debug, info, warn, error, fatal)",
-                          :type => String,
-                          :validate => ->(level) { ["error", "fatal", "debug", "warn", "info"].include?(level) }
-
-        super
       end
 
       def post_option_parser(configuration)
@@ -87,16 +139,34 @@ module MCollective
         else
           abort("Please specify a command, valid commands are: %s" % valid_commands.join(", "))
         end
+
+        if input = configuration[:__json_input]
+          result = {}
+
+          if input.start_with?("@")
+            input.sub!("@", "")
+            result = JSON.parse(File.read(input)) if input.end_with?("json")
+            result = YAML.safe_load(File.read(input)) if input.end_with?("yaml")
+          else
+            result = JSON.parse(input)
+          end
+
+          configuration.merge!(result)
+        end
       end
 
       # Validates the configuration
       #
       # @return [void]
       def validate_configuration(configuration)
-        abort("Please specify a playbook to run") unless configuration[:__playbook_file]
+        abort("Please specify a playbook to run") unless configuration[:__playbook]
 
         if options[:verbose] && !configuration.include?(:loglevel)
           configuration[:__loglevel] = "debug"
+        end
+
+        if configuration[:__report] && playbook_type == :plan
+          abort("Reports are only supported for YAML playbooks")
         end
       end
 
@@ -125,7 +195,53 @@ module MCollective
         pb_config = configuration.clone
         pb_config.delete_if {|k, _| k.to_s.start_with?("__")}
 
-        pb = playbook(configuration[:__playbook_file], configuration[:__loglevel])
+        pb = playbook(configuration[:__playbook], configuration[:__loglevel])
+
+        run_playbook(pb, pb_config) if playbook_type == :yaml
+        run_plan(pb, pb_config)
+      end
+
+      def run_plan(pb, pb_config)
+        startime = Time.now
+
+        success = true
+
+        result = pb.run!(pb_config)
+      rescue
+        success = false
+      ensure
+        disconnect
+
+        endtime = Time.now
+
+        color = :green
+        msg = "OK"
+
+        unless success
+          color = :red
+          msg = "FAILED"
+        end
+
+        puts
+        puts "Plan %s ran in %.2f seconds: %s" % [
+          Util.colorize(:bold, configuration[:__playbook]),
+          endtime - startime,
+          Util.colorize(color, msg)
+        ]
+
+        unless result.nil?
+          puts
+          puts "Result: "
+          puts
+          puts Util.align_text(JSON.pretty_generate(result), 10000)
+          puts
+        end
+
+        success ? exit(0) : exit(1)
+      end
+
+      def run_playbook(pb, pb_config)
+        Log.warn("YAML playbooks on the command line are deprecated and will be removed soon, please use Plan DSL playbooks")
 
         if configuration[:__report]
           # windows can't have : in file names, ffs
@@ -153,15 +269,6 @@ module MCollective
         end
 
         report["report"]["success"] ? exit(0) : exit(1)
-      end
-
-      def show_command
-        disconnect
-
-        pb = playbook(configuration[:__playbook_file], configuration[:__loglevel])
-        pb.validate_configuration!
-
-        puts YAML.dump(YAML.load_file(configuration[:__playbook_file]))
       end
 
       def main

--- a/lib/mcollective/util/bolt_support.rb
+++ b/lib/mcollective/util/bolt_support.rb
@@ -4,6 +4,7 @@ require_relative "playbook"
 
 require_relative "bolt_support/task_result"
 require_relative "bolt_support/task_results"
+require_relative "bolt_support/plan_runner"
 
 module MCollective
   module Util

--- a/lib/mcollective/util/bolt_support/plan_runner.rb
+++ b/lib/mcollective/util/bolt_support/plan_runner.rb
@@ -1,0 +1,148 @@
+require "puppet"
+require "puppet_pal"
+require "tmpdir"
+
+module MCollective
+  module Util
+    class BoltSupport
+      class PlanRunner
+        def self.init_puppet
+          TaskResults.include_iterable
+          Puppet::Util::Log.newdestination(:console)
+        end
+
+        init_puppet
+
+        # @param plan [String] the name of the plan to use
+        # @param tmpdir [String] the path to an already existing temporary directory
+        # @param modulepath [String] a : seperated list of locations to look for modules
+        # @param loglevel [debug, info, warn, err]
+        def initialize(plan, tmpdir, modulepath, loglevel)
+          @plan = plan
+          @loglevel = loglevel
+          @modulepath = Array(modulepath)
+          @tmpdir = tmpdir
+
+          raise("A temporary directory could not be created") unless @tmpdir
+          raise("A temporary directory could not be created") unless File.directory?(@tmpdir)
+
+          Puppet[:log_level] = @loglevel
+        end
+
+        # Determines if the requested plan exist
+        #
+        # @return [Boolean]
+        def exist?
+          with_script_compiler do |compiler|
+            return !!compiler.plan_signature(@plan)
+          end
+        end
+
+        # Initialize Puppet to use the configured tmp dir
+        def puppet_cli_options
+          Puppet::Settings::REQUIRED_APP_SETTINGS.map do |setting|
+            "--%s %s" % [setting, @tmpdir]
+          end
+        end
+
+        # Retrieves the signature of a plan - its parameters and types
+        #
+        # NOTE: at present it's not possible to extract description or default values
+        #
+        # @return [Hash]
+        def plan_signature
+          with_script_compiler do |compiler|
+            sig = compiler.plan_signature(@plan)
+
+            raise("Cannot find plan %s in %s" % [@plan, @modulepath.join(":")]) unless sig
+
+            sig.params_type.elements.map do |elem|
+              [elem.name, {
+                "type" => elem.value_type.to_s,
+                "required" => !elem.key_type.is_a?(Puppet::Pops::Types::POptionalType)
+              }]
+            end
+          end
+        end
+
+        # Yields a PAL script compiler in the temporary environment
+        def with_script_compiler
+          in_environment do |env|
+            env.with_script_compiler do |compiler|
+              yield(compiler)
+            end
+          end
+        end
+
+        # Sets up a temporary environment
+        def in_environment
+          Puppet.initialize_settings(puppet_cli_options) unless Puppet.settings.global_defaults_initialized?
+
+          Puppet::Pal.in_tmp_environment("choria", :modulepath => @modulepath, :facts => {}) do |env|
+            yield(env)
+          end
+        end
+
+        # Converts a Puppet type into something mcollective understands
+        #
+        # This is inevitably hacky by its nature, there is no way for me to
+        # parse the types.  PAL might get some helpers for this but till then
+        # this is going to have to be best efforts.
+        #
+        # When there is a too complex situation users can always put in --input
+        # and some JSON to work around it until something better comes around
+        #
+        # @param type [String] a puppet type
+        # @return [Class, Boolean] The data type, if its an array input or not
+        def puppet_type_to_ruby(type)
+          array = false
+
+          type = $1 if type =~ /Optional\[(.+)/
+
+          if type =~ /Array\[(.+)/
+            type = $1
+            array = true
+          end
+
+          return [Numeric, array] if type =~ /Integer/
+          return [Numeric, array] if type =~ /Float/
+          return [Hash, array] if type =~ /Hash/
+          return [:boolean, array] if type =~ /Boolean/
+
+          [String, array]
+        end
+
+        def run!(params)
+          with_script_compiler do |compiler|
+            compiler.call_function("choria::run_playbook", @plan, params)
+          end
+        end
+
+        # Adds the CLI options for an application based on the playbook inputs
+        #
+        # @param application [MCollective::Application]
+        # @param set_required [Boolean]
+        def add_cli_options(application, set_required=false)
+          sig = plan_signature
+
+          return if sig.nil? || sig.empty?
+
+          sig.each do |name, details|
+            type, array = puppet_type_to_ruby(details["type"])
+
+            properties = {
+              :description => "Plan input property (%s)" % details["type"],
+              :arguments => "--%s %s" % [name.downcase, name.upcase],
+              :type => array ? :array : type
+            }
+
+            properties[:required] = true if details["required"] && set_required
+            properties[:arguments] = "--%s" % name.downcase if type == :boolean
+
+            application.class.option(name, properties)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/bolt_support/task_result.rb
+++ b/lib/mcollective/util/bolt_support/task_result.rb
@@ -19,6 +19,10 @@ module MCollective
           @result = result
         end
 
+        def to_json(o={})
+          {@host => @result}.to_json(o)
+        end
+
         # A error object if this represents an error
         #
         # @return [Puppet::DataTypes::Error, nil]

--- a/lib/mcollective/util/bolt_support/task_results.rb
+++ b/lib/mcollective/util/bolt_support/task_results.rb
@@ -24,6 +24,10 @@ module MCollective
           @results = results
         end
 
+        def to_json(o={})
+          @results.to_json(o)
+        end
+
         # Iterate over all results
         #
         # @yield [TaskResult]

--- a/lib/mcollective/util/playbook.rb
+++ b/lib/mcollective/util/playbook.rb
@@ -8,8 +8,6 @@ require_relative "playbook/nodes"
 require_relative "playbook/tasks"
 require_relative "playbook/data_stores"
 
-require "semantic_puppet"
-
 module MCollective
   module Util
     class Playbook

--- a/lib/mcollective/util/playbook/tasks/slack_task.rb
+++ b/lib/mcollective/util/playbook/tasks/slack_task.rb
@@ -85,7 +85,7 @@ module MCollective
             data = JSON.parse(data || resp.body)
 
             if resp.code == "200" && data["ok"]
-              Log.info("Successfully sent message to slack channel %s" % [@channel])
+              Log.debug("Successfully sent message to slack channel %s" % [@channel])
               [true, "Message submitted to slack channel %s" % [@channel], [data]]
             else
               Log.warn("Failed to send message to slack channel %s: %s" % [@channel, data["error"]])

--- a/lib/mcollective/util/playbook/uses.rb
+++ b/lib/mcollective/util/playbook/uses.rb
@@ -104,6 +104,8 @@ module MCollective
         def valid_version?(have, want)
           have = "%s.0" % have if have.split(".").size == 2
 
+          require "semantic_puppet" unless defined?(SemanticPuppet)
+
           semver_have = SemanticPuppet::Version.parse(have)
           semver_want = SemanticPuppet::VersionRange.parse(want)
           semver_want.include?(semver_have)

--- a/module/choria/data/plugin.yaml
+++ b/module/choria/data/plugin.yaml
@@ -20,6 +20,7 @@ mcollective_choria::client_files:
  - util/bolt_support.rb
  - util/bolt_support/task_result.rb
  - util/bolt_support/task_results.rb
+ - util/bolt_support/plan_runner.rb
  - util/playbook.rb
  - util/playbook/data_stores.rb
  - util/playbook/data_stores/base.rb

--- a/spec/fixtures/bolt/plans/mymod/plans/test.pp
+++ b/spec/fixtures/bolt/plans/mymod/plans/test.pp
@@ -1,0 +1,7 @@
+plan mymod::test (
+  Boolean $b = false,
+  String $s = "default",
+  Array[String] $as = ["empty"],
+  $notype = ""
+) {
+}

--- a/spec/unit/mcollective/util/bolt_support/plan_runner_spec.rb
+++ b/spec/unit/mcollective/util/bolt_support/plan_runner_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+require "mcollective/util/bolt_support"
+require "puppet"
+
+module MCollective
+  module Util
+    class BoltSupport
+      describe PlanRunner do
+        let(:tmpdir) { Dir.mktmpdir("rspec") }
+        let(:runner) { PlanRunner.new("mymod::test", tmpdir, "spec/fixtures/bolt/plans", "err") }
+
+        after(:each) do
+          FileUtils.rm_rf(tmpdir)
+        end
+
+        describe "#exist?" do
+          it "should detect known plans" do
+            expect(runner).to exist
+          end
+
+          it "should detect missing plans" do
+            runner.instance_variable_set("@plan", "mymod::fail")
+            expect(runner).to_not exist
+          end
+        end
+
+        describe "#puppet_type_to_ruby" do
+          it "should handle arrays" do
+            expect(runner.puppet_type_to_ruby("Array[Integer]")).to eq([Numeric, true])
+            expect(runner.puppet_type_to_ruby("Optional[Array[Integer]]")).to eq([Numeric, true])
+          end
+
+          it "should handle Integers" do
+            expect(runner.puppet_type_to_ruby("Integer")).to eq([Numeric, false])
+            expect(runner.puppet_type_to_ruby("Optional[Integer]")).to eq([Numeric, false])
+          end
+
+          it "should handle Floarunner" do
+            expect(runner.puppet_type_to_ruby("Float")).to eq([Numeric, false])
+            expect(runner.puppet_type_to_ruby("Optional[Float]")).to eq([Numeric, false])
+          end
+
+          it "should handle Hashes" do
+            expect(runner.puppet_type_to_ruby("Hash")).to eq([Hash, false])
+            expect(runner.puppet_type_to_ruby("Optional[Hash]")).to eq([Hash, false])
+          end
+
+          it "should handle Enums" do
+            expect(runner.puppet_type_to_ruby("Enum[foo, bar]")).to eq([String, false])
+            expect(runner.puppet_type_to_ruby("Optional[Enum[foo, bar]]")).to eq([String, false])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This does a first pass through making plans at least work, its not
pretty as there is a lot of yaml/plan code mashed together in the app

I think we will deprecate and remove the YAML stuff from the CLI - but
retain the code for a future playbook service - and push people to plans
so it's not really worth it right now to spend a ton of time on
extracting all this into a yaml and plan specific set of code when the
worst of it will just be removed soon