### PR TITLE
(#463) Fix puppetdb request when fact is a numeric value

### DIFF
--- a/lib/mcollective/discovery/choria.rb
+++ b/lib/mcollective/discovery/choria.rb
@@ -132,13 +132,13 @@ module MCollective
 
             'inventory {facts.%s ~ "%s"}' % [fact, regex]
           when "=="
-            if ["true", "false"].include?(value)
+            if ["true", "false"].include?(value) || numeric?(value)
               'inventory {facts.%s = %s or facts.%s = "%s"}' % [fact, value, fact, value]
             else
               'inventory {facts.%s = "%s"}' % [fact, value]
             end
           when "!="
-            if ["true", "false"].include?(value)
+            if ["true", "false"].include?(value) || numeric?(value)
               'inventory {!(facts.%s = %s or facts.%s = "%s")}' % [fact, value, fact, value]
             else
               'inventory {!(facts.%s = "%s")}' % [fact, value]


### PR DESCRIPTION
If the fact value is numeric, the puppetdb query perfom an or with and without quotes
