### PR TITLE
(#472) Ensure zero input tasks work

### DIFF
--- a/lib/mcollective/util/tasks_support/cli.rb
+++ b/lib/mcollective/util/tasks_support/cli.rb
@@ -158,9 +158,7 @@ module MCollective
             result[item.to_s] = value
           end
 
-          return result unless result.empty?
-
-          abort("Could not parse input from --input as YAML or JSON")
+          result
         end
 
         # Validates the inputs provided on the CLI would be acceptable to the task


### PR DESCRIPTION
Previously the code incorrectly assumed that when it was unable to
find any inputs in any of the supported ways that obviously it's
bad and failed.  But it does not consider that some tasks have no
inputs and so that's totally ok.