### PR TITLE
(#478) support accepting hash argumentson the cli

### DIFF
--- a/lib/mcollective/application/playbook.rb
+++ b/lib/mcollective/application/playbook.rb
@@ -184,7 +184,7 @@ module MCollective
           Util.colorize(color, msg)
         ]
 
-        unless result.nil?
+        if result
           puts
           puts "Result: "
           puts

--- a/lib/mcollective/application/tasks.rb
+++ b/lib/mcollective/application/tasks.rb
@@ -154,6 +154,7 @@ Examples:
           abort($!.to_s)
         end
 
+        cli.transform_hash_strings(meta, input)
         cli.validate_task_input(task, meta, input)
 
         say("Attempting to download and run task %s on %d nodes" % [Util.colorize(:bold, task), bolt_tasks.discover.size])

--- a/spec/unit/mcollective/util/tasks_support/cli_spec.rb
+++ b/spec/unit/mcollective/util/tasks_support/cli_spec.rb
@@ -12,6 +12,29 @@ module MCollective
         let(:cli) { ts.cli(:console, true) }
         let(:task_fixture) { JSON.parse(File.read("spec/fixtures/tasks/tasks_list.json")) }
 
+        describe "#transform_hash_strings" do
+          it "should transform a json string to hash if the input is a hash" do
+            inputs = {
+              "params" => '{"message":"hello world"}'
+            }
+
+            meta = {
+              "metadata" => {
+                "parameters" => {
+                  "params" => {
+                    "description" => "A map of parameter names and values to apply",
+                    "type" => "Optional[Hash[String[1], Data]]"
+                  }
+                }
+              }
+            }
+
+            cli.transform_hash_strings(meta, inputs)
+
+            expect(inputs["params"]).to eq("message" => "hello world")
+          end
+        end
+
         describe "#task_metadata" do
           it "should fetch and cache the metadata" do
             fixture = JSON.parse(File.read("spec/fixtures/tasks/puppet_conf_metadata.json"))


### PR DESCRIPTION
Previously the code attempted to pass Hash as a type to the
option parser for any hash data which option parser does not
support and so it would just fail

This leaves the question of how to handle hash inputs and what
to surface in --help, so I am doing this:

   --params JSON  A map of parameter names and values to apply (Optional[Hash])

Now someone can do --params '{"foo":"bar"}' and it will attempt
to JSON parse that input, alternatively the --params can just be
left off entirely and given using --json

Additionally this fixes #479 by removing the required flags of
required inputs.  This failed because if I did not specify a
required input using --foo but in the JSON for --input then the
option parser would fail the app before it even gets to checking
if the required input was given in the JSON.  Now it does and rely
on our own internal checks for the optional/required later