### PR TITLE
(#498) expose task details to the environment

### DIFF
--- a/lib/mcollective/util/tasks_support.rb
+++ b/lib/mcollective/util/tasks_support.rb
@@ -155,9 +155,15 @@ module MCollective
       # Given a task spec calculates the correct environment hash
       #
       # @param task [Hash] task specification
+      # @param task_id [String] task id - usually the mcollective request id
+      # @param task_caller [String] the caller invoking the task
       # @return [Hash]
-      def task_environment(task)
-        environment = {}
+      def task_environment(task, task_id, task_caller)
+        environment = {
+          "_task" => task["task"],
+          "_task_id" => task_id,
+          "_task_caller" => task_caller
+        }
 
         return environment unless task["input"]
         return environment unless ["both", "environment"].include?(task_input_method(task))
@@ -316,7 +322,7 @@ module MCollective
           meta.print(data.to_json)
         end
 
-        pid = spawn_command(wrapper_path, task_environment(task), wrapper_input.to_json, spool)
+        pid = spawn_command(wrapper_path, task_environment(task, requestid, callerid), wrapper_input.to_json, spool)
 
         Log.info("Spawned task %s in spool %s with pid %s" % [task["task"], spool, pid])
 

--- a/spec/unit/mcollective/util/tasks_support_spec.rb
+++ b/spec/unit/mcollective/util/tasks_support_spec.rb
@@ -261,7 +261,11 @@ ERROR
           ts.stubs(:request_spooldir).returns(File.join(cache, "test_1"))
           ts.expects(:spawn_command).with(
             "/opt/puppetlabs/puppet/bin/task_wrapper",
-            {},
+            {
+              "_task" => "choria::ls",
+              "_task_id" => "test_1",
+              "_task_caller" => "choria=local.mcollective"
+            },
             instance_of(String),
             File.join(cache, "test_1")
           )
@@ -270,7 +274,7 @@ ERROR
           ts.expects(:wait_for_task_completion)
           ts.stubs(:task_status)
 
-          ts.run_task_command("test_1", task_run_request_fixture)
+          ts.run_task_command("test_1", task_run_request_fixture, true, "choria=local.mcollective")
         end
       end
 
@@ -370,14 +374,24 @@ ERROR
           ["both", "environment"].each do |method|
             task_run_request_fixture["input_method"] = method
             task_run_request_fixture["input"] = '{"directory": "/tmp", "bool":true}'
-            expect(ts.task_environment(task_run_request_fixture)).to eq("PT_directory" => "/tmp", "PT_bool" => "true")
+            expect(ts.task_environment(task_run_request_fixture, "test_id", "caller=spec.mcollective")).to eq(
+              "PT_directory" => "/tmp",
+              "PT_bool" => "true",
+              "_task" => "choria::ls",
+              "_task_caller" => "caller=spec.mcollective",
+              "_task_id" => "test_id"
+            )
           end
         end
 
         it "should not set it otherwise" do
           ["powershell", "stdin"].each do |method|
             task_run_request_fixture["input_method"] = method
-            expect(ts.task_environment(task_run_request_fixture)).to be_empty
+            expect(ts.task_environment(task_run_request_fixture, "test_id", "caller=spec.mcollective")).to eq(
+              "_task" => "choria::ls",
+              "_task_caller" => "caller=spec.mcollective",
+              "_task_id" => "test_id"
+            )
           end
         end
       end


### PR DESCRIPTION
When running a task via the agent this will set _task, _task_id and
_task_caller in the environment