### PR TITLE
(#504) Rename _task_id and _task_caller to choria specific versions

### DIFF
--- a/lib/mcollective/util/tasks_support.rb
+++ b/lib/mcollective/util/tasks_support.rb
@@ -161,8 +161,8 @@ module MCollective
       def task_environment(task, task_id, task_caller)
         environment = {
           "_task" => task["task"],
-          "_task_id" => task_id,
-          "_task_caller" => task_caller
+          "_choria_task_id" => task_id,
+          "_choria_task_caller" => task_caller
         }
 
         return environment unless task["input"]

--- a/spec/unit/mcollective/util/tasks_support_spec.rb
+++ b/spec/unit/mcollective/util/tasks_support_spec.rb
@@ -263,8 +263,8 @@ ERROR
             "/opt/puppetlabs/puppet/bin/task_wrapper",
             {
               "_task" => "choria::ls",
-              "_task_id" => "test_1",
-              "_task_caller" => "choria=local.mcollective"
+              "_choria_task_id" => "test_1",
+              "_choria_task_caller" => "choria=local.mcollective"
             },
             instance_of(String),
             File.join(cache, "test_1")
@@ -378,8 +378,8 @@ ERROR
               "PT_directory" => "/tmp",
               "PT_bool" => "true",
               "_task" => "choria::ls",
-              "_task_caller" => "caller=spec.mcollective",
-              "_task_id" => "test_id"
+              "_choria_task_caller" => "caller=spec.mcollective",
+              "_choria_task_id" => "test_id"
             )
           end
         end
@@ -389,8 +389,8 @@ ERROR
             task_run_request_fixture["input_method"] = method
             expect(ts.task_environment(task_run_request_fixture, "test_id", "caller=spec.mcollective")).to eq(
               "_task" => "choria::ls",
-              "_task_caller" => "caller=spec.mcollective",
-              "_task_id" => "test_id"
+              "_choria_task_caller" => "caller=spec.mcollective",
+              "_choria_task_id" => "test_id"
             )
           end
         end


### PR DESCRIPTION
As the Task support is based on the offical specification we cannot
deviate by much and if we do it should be clear its a local extension
and also be safe that as the spec evolve it won't kill our extensions

We add _task_id and _task_caller environment variables when _task was
added but only _task is official

These are now _choria_task_id and _choria_task_caller