### PR TITLE
(#511) Reduce logging in network loops

### DIFF
--- a/lib/mcollective/connector/nats.rb
+++ b/lib/mcollective/connector/nats.rb
@@ -359,9 +359,9 @@ module MCollective
         msg = nil
 
         until msg
-          Log.debug("Waiting for a message from NATS")
-
           received = connection.receive
+
+          Thread.pass
 
           begin
             msg = JSON.parse(received)

--- a/lib/mcollective/util/natswrapper.rb
+++ b/lib/mcollective/util/natswrapper.rb
@@ -210,8 +210,7 @@ module MCollective
           Log.debug("Subscribing to %s" % source_name)
 
           unless @subscriptions.include?(source_name)
-            @subscriptions[source_name] = @client.subscribe(source_name, options) do |msg, _, sub|
-              Log.debug("Received a message on %s" % [sub])
+            @subscriptions[source_name] = @client.subscribe(source_name, options) do |msg, _, _|
               @received_queue << msg
             end
           end


### PR DESCRIPTION
Upcoming NATS broker will be significantly faster and so add a lot more
strain on these 2 code paths

Removing the log lines let it work unbatched for smallisy payload on 50k
nodes but really there's only so far this will go and we're getting
there now