### PR TITLE
(#513) set puppet upper version boundary to 6.0.0

### DIFF
--- a/module/choria/metadata.json
+++ b/module/choria/metadata.json
@@ -18,7 +18,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.9.0"
+      "version_requirement": ">= 4.9.0 < 6.0.0"
     }
   ]
 }


### PR DESCRIPTION
This is needed to make certain puppet-lint checks happy and also
considered best practice.

Fixes #513