### PR TITLE
(#544) Improve backward compatibility in JSON mode

### DIFF
--- a/lib/mcollective/security/choria.rb
+++ b/lib/mcollective/security/choria.rb
@@ -3,6 +3,7 @@ require "openssl"
 require "yaml"
 
 require_relative "../util/choria"
+require_relative "../util/indifferent_hash"
 
 module MCollective
   module Security
@@ -502,7 +503,7 @@ module MCollective
         if format == :yaml
           YAML.load(string)
         else
-          JSON.parse(string)
+          JSON.parse(string, :object_class => Util::IndifferentHash)
         end
       end
 

--- a/lib/mcollective/util/indifferent_hash.rb
+++ b/lib/mcollective/util/indifferent_hash.rb
@@ -1,0 +1,12 @@
+module MCollective
+  module Util
+    class IndifferentHash < Hash
+      def [](key)
+        return super if key?(key)
+        return self[key.to_s] if key.is_a?(Symbol)
+
+        super
+      end
+    end
+  end
+end

--- a/spec/unit/mcollective/security/choria_spec.rb
+++ b/spec/unit/mcollective/security/choria_spec.rb
@@ -448,7 +448,9 @@ module MCollective
       let(:d) { security.empty_request }
 
       it "should default to json" do
-        expect(security.deserialize(d.to_json)).to eq(d)
+        result = security.deserialize(d.to_json)
+        expect(result).to eq(d)
+        expect(result).to be_a(Util::IndifferentHash)
       end
 
       it "should support yaml" do

--- a/spec/unit/mcollective/util/indifferent_hash_spec.rb
+++ b/spec/unit/mcollective/util/indifferent_hash_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "mcollective/util/indifferent_hash"
+
+module MCollective
+  module Util
+    describe IndifferentHash do
+      describe "#[]" do
+        it "should correctly grant indifferent access" do
+          h = IndifferentHash["x" => "y"]
+          expect(h[:x]).to eq("y")
+          expect(h["x"]).to eq("y")
+
+          h = IndifferentHash[:x => "y"]
+          expect(h[:x]).to eq("y")
+          expect(h["x"]).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This create a Hash variant that allow :x to access "x" if :x does not
exist, it uses this in the JSON deserialize to improve backwards compat
for the old hashes that was in yaml

With this code in place `mco facts` works again unmodified