### PR TITLE
(#563) support a remote signing service

### DIFF
--- a/lib/mcollective/signer/base.rb
+++ b/lib/mcollective/signer/base.rb
@@ -1,0 +1,27 @@
+module MCollective
+  module Signer
+    class Base
+      # Register plugins that inherits base
+      def self.inherited(klass)
+        PluginManager << {:type => "choria_signer_plugin", :class => klass.to_s}
+      end
+
+      def initialize
+        @config = Config.instance
+        @log = Log
+      end
+
+      # Signs a secure request
+      #
+      # Generally for local mode this would just use the users own certificate but if you have a
+      # remote signer this might use a token to speak to a remote API, by default Choria supports
+      # a standard web service for remote signatures
+      #
+      # @param secure_request [Hash] a choria:secure:request:1 hash
+      # @raise [StandardError] when signing fails
+      def sign_secure_request!(secure_request)
+        raise(NoMethodError, "undefined method `sign_secure_request!' for %s" % inspect)
+      end
+    end
+  end
+end

--- a/lib/mcollective/signer/choria.rb
+++ b/lib/mcollective/signer/choria.rb
@@ -1,0 +1,144 @@
+require_relative "base"
+
+module MCollective
+  module Signer
+    # This is a Secure Request Signer that allows either local signing of requests using the users
+    # own certificate or delegation based signing via a webservice
+    #
+    # This allows one to integrate the Choria CLI into a centralised authentication, authorization and
+    # auditing system
+    #
+    # Available settings:
+    #
+    #   choria.security.request_signer.plugin - the plugin to use, `choria` for this one - the default.
+    #   choria.security.request_signer.token_file - a file holding a token like a JWT or similar
+    #   choria.security.request_signer.token_environment - a ENV key holding a token like a JWT or similar
+    #   choria.security.request_signer.url - a endpoint that implements the v1 signer protocol
+    #
+    # The webservice has to support the specification found at https://choria.io/schemas/choria/signer/v1/service.json
+    class Choria < Base
+      # Retrieves the token from either a local file or the users environment
+      #
+      # @return [String, nil]
+      def token
+        file = @config.pluginconf["choria.security.request_signer.token_file"]
+        env = @config.pluginconf["choria.security.request_signer.token_environment"]
+
+        return File.read(File.expand_path(file)).chomp if file
+
+        raise("could not find token in environment variable %s" % env) unless ENV[env]
+
+        ENV[env].chomp
+      end
+
+      # Signs the secure request
+      #
+      # Signing supports either local mode using local certificates or delegating to a remote
+      # signer that is written in conformance with the signer specification version 1
+      #
+      # @param secure_request [Hash] a v1 secure request
+      def sign_secure_request!(secure_request)
+        return if $choria_unsafe_disable_protocol_security # rubocop:disable Style/GlobalVars
+
+        if remote_signer?
+          remote_sign!(secure_request)
+        else
+          local_sign!(secure_request)
+        end
+      end
+
+      # The body that would be submitted to the remote service
+      #
+      # @param secure_request [Hash] a v1 secure request
+      # @return [Hash]
+      def sign_request_body(secure_request)
+        {
+          "token" => token,
+          "request" => Base64.encode64(secure_request["message"])
+        }
+      end
+
+      # Performs a remote sign operation against a configured web service
+      #
+      # @param secure_request [Hash] a v1 secure request
+      # @raise [StandardError] on signing error
+      def remote_sign!(secure_request)
+        Log.info("Signing secure request using remote signer %s" % remote_signer_url)
+
+        uri = remote_signer_url
+        post = choria.http_post(uri.request_uri)
+        post.body = sign_request_body(secure_request).to_json
+
+        http = choria.https(:target => uri.host, :port => uri.port)
+        http.use_ssl = false if uri.scheme == "http"
+
+        resp = http.request(post)
+
+        signature = {}
+
+        if resp.code == "200"
+          signature = JSON.parse(resp.body)
+        else
+          raise("Could not get remote signature: %s: %s" % [resp.code, resp.body])
+        end
+
+        if signature["error"]
+          raise("Could not get remote signature: %s" % signature["error"])
+        end
+
+        signed_request = JSON.parse(Base64.decode64(signature["secure_request"]))
+        signed_request.each do |k, v|
+          secure_request[k] = v
+        end
+      end
+
+      # Signs using local certificates
+      #
+      # @param secure_request [Hash] a v1 secure request
+      # @raise [StandardError] on signing error
+      def local_sign!(secure_request)
+        Log.info("Signing secure request using local credentials")
+
+        secure_request["signature"] = sign(secure_request["message"])
+        secure_request["pubcert"] = File.read(client_public_cert).chomp
+
+        nil
+      end
+
+      # (see Security::Choria#sign)
+      def sign(string, id=nil)
+        security.sign(string, id)
+      end
+
+      # (see Security::Choria#client_public_cert)
+      def client_public_cert
+        security.client_public_cert
+      end
+
+      # Determines if a remote signer is configured
+      #
+      # @return [Boolean]
+      def remote_signer?
+        !!(remote_signer_url == "" || remote_signer_url)
+      end
+
+      # Determines the remote url to submit standard signing requests to
+      #
+      # @return [URI, Nil]
+      def remote_signer_url
+        return nil unless @config.pluginconf["choria.security.request_signer.url"]
+        return nil if @config.pluginconf["choria.security.request_signer.url"] == ""
+
+        URI.parse(@config.pluginconf["choria.security.request_signer.url"])
+      end
+
+      def security
+        @security ||= PluginManager["security_plugin"]
+      end
+
+      def choria
+        @choria ||= security.choria
+      end
+    end
+  end
+end

--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -259,6 +259,20 @@ module MCollective
         Net::HTTP::Get.new(path, headers)
       end
 
+      # Creates a Net::HTTP::Post instance for a path that defaults to accepting JSON
+      #
+      # @param path [String]
+      # @return [Net::HTTP::Post]
+      def http_post(path, headers=nil)
+        headers ||= {}
+        headers = {
+          "Accept" => "application/json",
+          "User-Agent" => "Choria version %s http://choria.io" % VERSION
+        }.merge(headers)
+
+        Net::HTTP::Post.new(path, headers)
+      end
+
       # Does a proxied discovery request
       #
       # @param query [Hash] Discovery query as per pdbproxy standard

--- a/spec/unit/mcollective/signer/choria_spec.rb
+++ b/spec/unit/mcollective/signer/choria_spec.rb
@@ -1,0 +1,165 @@
+require "spec_helper"
+
+require "mcollective/security/choria"
+require "mcollective/signer/choria"
+
+module MCollective
+  describe Signer::Choria do
+    let(:signer) { Signer::Choria.new }
+    let(:security) { Security::Choria.new }
+
+    before(:each) do
+      Config.instance.pluginconf.clear
+      MCollective::PluginManager.stubs(:[]).with("security_plugin").returns(security)
+      security.stubs(:current_timestamp).returns(1464002319)
+    end
+
+    describe "#remote_sign" do
+      before(:each) do
+        Config.instance.pluginconf["choria.security.request_signer.url"] = "http://localhost:8080/choria/v1/sign"
+        ENV["choria_token"] = "test_env_token"
+        Config.instance.pluginconf["choria.security.request_signer.token_environment"] = "choria_token"
+      end
+
+      it "should handle succesful signs" do
+        signed = {
+          "message" => "too many secrets",
+          "signature" => File.read("spec/fixtures/too_many_secrets.sig"),
+          "pubcert" => File.read("spec/fixtures/rip.mcollective.pem").chomp
+        }.to_json
+
+        response = {"secure_request" => Base64.encode64(signed)}.to_json
+
+        stub_request(:post, "http://localhost:8080/choria/v1/sign").to_return(:status => 200, :body => response)
+
+        sr = {"message" => "too many secrets"}
+        signer.remote_sign!(sr)
+
+        expect(sr["signature"]).to eq(File.read("spec/fixtures/too_many_secrets.sig"))
+        expect(sr["pubcert"]).to eq(File.read("spec/fixtures/rip.mcollective.pem").chomp)
+      end
+
+      it "should handle signs with a error" do
+        response = {"secure_request" => "", "error" => "simulated failure"}.to_json
+        stub_request(:post, "http://localhost:8080/choria/v1/sign").to_return(:status => 200, :body => response)
+
+        sr = {"message" => "too many secrets"}
+
+        expect { signer.remote_sign!(sr) }.to raise_error("Could not get remote signature: simulated failure")
+      end
+
+      it "should handle request failures" do
+        stub_request(:post, "http://localhost:8080/choria/v1/sign").to_return(:status => 500, :body => "not available")
+
+        sr = {"message" => "too many secrets"}
+
+        expect { signer.remote_sign!(sr) }.to raise_error("Could not get remote signature: 500: not available")
+      end
+    end
+
+    describe "#local_sign" do
+      it "should correctly sign the request" do
+        security.initiated_by = :client
+        security.choria.expects(:client_private_key).returns("spec/fixtures/rip.mcollective.key").twice
+        security.choria.expects(:client_public_cert).returns("spec/fixtures/rip.mcollective.pem")
+
+        sr = {"message" => "too many secrets"}
+        signer.local_sign!(sr)
+        expect(sr["signature"]).to eq(File.read("spec/fixtures/too_many_secrets.sig"))
+        expect(sr["pubcert"]).to eq(File.read("spec/fixtures/rip.mcollective.pem").chomp)
+      end
+    end
+
+    describe "#remote_signer_url" do
+      it "should support unset" do
+        expect(signer.remote_signer_url).to be_nil
+      end
+
+      it "should support empty" do
+        Config.instance.pluginconf["choria.security.request_signer.url"] = ""
+        expect(signer.remote_signer_url).to be_nil
+      end
+
+      it "should parse the url" do
+        Config.instance.pluginconf["choria.security.request_signer.url"] = "https://localhost:8080"
+        uri = signer.remote_signer_url
+        expect(uri.host).to eq("localhost")
+        expect(uri.port).to eq(8080)
+      end
+    end
+
+    describe "#remote_signer?" do
+      it "should support unset urls" do
+        expect(signer.remote_signer?).to be(false)
+      end
+
+      it "should support '' urls" do
+        Config.instance.pluginconf["choria.security.request_signer.url"] = ""
+        expect(signer.remote_signer?).to be(false)
+      end
+
+      it "should support set urls" do
+        Config.instance.pluginconf["choria.security.request_signer.url"] = "http://localhost:8080"
+        expect(signer.remote_signer?).to be(true)
+      end
+    end
+
+    describe "#token" do
+      it "should support file tokens" do
+        file = Tempfile.new("token")
+        file.write("test_token")
+        file.close
+
+        Config.instance.pluginconf["choria.security.request_signer.token_file"] = file.path
+
+        begin
+          expect(signer.token).to eq("test_token")
+        ensure
+          file.unlink
+        end
+      end
+
+      it "should support environment tokens" do
+        ENV["choria_token"] = "test_env_token"
+        Config.instance.pluginconf["choria.security.request_signer.token_environment"] = "choria_token"
+        expect(signer.token).to eq("test_env_token")
+      end
+    end
+
+    describe "sign_secure_request!" do
+      it "should support disabling protocol security" do
+        $choria_unsafe_disable_protocol_security = true # rubocop:disable Style/GlobalVars
+        signer.expects(:remote_signer?).never
+
+        begin
+          signer.sign_secure_request!({})
+        ensure
+          $choria_unsafe_disable_protocol_security = false # rubocop:disable Style/GlobalVars
+        end
+      end
+
+      it "should support remote signing" do
+        Config.instance.pluginconf["choria.security.request_signer.url"] = "http://localhost:8080"
+        signer.expects(:remote_sign!).once
+        signer.sign_secure_request!({})
+      end
+
+      it "should support local signing" do
+        Config.instance.pluginconf.delete("choria.security.request_signer.url")
+        signer.expects(:local_sign!).once
+        signer.sign_secure_request!({})
+      end
+    end
+
+    describe "#sign_request_body" do
+      it "should create the correct body" do
+        ENV["CHORIA_TOKEN"] = "test_env_token"
+        Config.instance.pluginconf["choria.security.request_signer.token_environment"] = "CHORIA_TOKEN"
+
+        result = signer.sign_request_body("message" => "hello world")
+        expect(result["token"]).to eq("test_env_token")
+        expect(result["request"]).to eq(Base64.encode64("hello world"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for delegating the signing of requests to a remote
service that uses the Privileged Certificate feature of the security
subsystem to delegate signing, authorization and auditing to a central
authority