### PR TITLE
(#416) render results as a string if so

### DIFF
--- a/lib/mcollective/application/playbook.rb
+++ b/lib/mcollective/application/playbook.rb
@@ -184,7 +184,11 @@ module MCollective
           puts
           puts "Result: "
           puts
-          puts Util.align_text(JSON.pretty_generate(result), 10000)
+          if result.class != String
+            puts Util.align_text(JSON.pretty_generate(result), 10000)
+          else
+            puts result
+          end
           puts
         end
 


### PR DESCRIPTION
Add string detection to results, which will allow for the use of `epp()`
and friends to summarize the output