### PR TITLE
(#616) Extract playbook name correcly from facts

### DIFF
--- a/lib/mcollective/util/bolt_support.rb
+++ b/lib/mcollective/util/bolt_support.rb
@@ -171,9 +171,9 @@ module MCollective
       def assign_playbook_name(scope)
         return unless scope
         return unless scope["facts"]["choria"]
-        return unless scope["facts"]["choria"]["plan"]
+        return unless scope["facts"]["choria"]["playbook"]
 
-        playbook.metadata["name"] = scope["facts"]["choria"]["plan"]
+        playbook.metadata["name"] = scope["facts"]["choria"]["playbook"]
       end
     end
   end

--- a/spec/unit/mcollective/util/bolt_support_spec.rb
+++ b/spec/unit/mcollective/util/bolt_support_spec.rb
@@ -17,7 +17,7 @@ module MCollective
       describe "#assign_playbook_name" do
         it "should assign the playbook name from scope" do
           expect(playbook.name).to be_nil
-          support.assign_playbook_name("facts" => {"choria" => {"plan" => "rspec"}})
+          support.assign_playbook_name("facts" => {"choria" => {"playbook" => "rspec"}})
           expect(playbook.name).to eq("rspec")
         end
 


### PR DESCRIPTION
As discussed on slack, this changes the way that the playbook name is extracted from the choria facts such that the playbook name is correctly recovered. 

I haven't had time to run the unit tests unfortunately. 