### PR TITLE
(#623) Print CSR fingerprint in request_cert application

### DIFF
--- a/lib/mcollective/application/choria.rb
+++ b/lib/mcollective/application/choria.rb
@@ -95,6 +95,9 @@ module MCollective
         puts("Waiting up to 240 seconds for it to be signed")
         puts
 
+        puts("Key fingerprint: %s" % choria.csr_fingerprint)
+        puts
+
         24.times do |time|
           print "Attempting to download certificate %s: %d / 24\r" % [certname, time]
 

--- a/lib/mcollective/util/choria.rb
+++ b/lib/mcollective/util/choria.rb
@@ -872,6 +872,15 @@ module MCollective
         File.exist?(csr_path)
       end
 
+      # The formatted string representation of the CSR fingerprint
+      #
+      # @return [String]
+      def csr_fingerprint
+        require "puppet"
+        csr = OpenSSL::X509::Request.new(File.read(csr_path))
+        Puppet::SSL::Digest.new(nil, csr.to_der)
+      end
+
       # Searches the PATH for an executable command
       #
       # @param command [String] a command to search for


### PR DESCRIPTION
With this change, the fingerprint of the CSR is print to the user when
running `mco choria request_cert`.

This fingerprint is also shown when running `puppetserver ca list`, the
idea is to make it easy to check the requests match on both sides when
new users are enrolled and we try to teach them best practices.

Sample output:

```sh-session
romain@marvin /tmp $ USER=bob mco choria request_cert --config client.cfg
Certificate /tmp/ssl/certs/bob.mcollective.pem has already been requested, attempting to retrieve it
Waiting up to 240 seconds for it to be signed

Key fingerprint: (SHA256) 44:84:F4:F8:88:7B:E4:97:9C:47:B6:3A:E1:36:C2:C6:D0:FF:DA:A9:23:B9:5D:62:74:C3:8D:3C:0C:1D:ED:FA

Attempting to download certificate /tmp/ssl/certs/bob.mcollective.pem: 0 / 24
```