### PR TITLE
(#638) Workaround for unbreaking discovery

### DIFF
--- a/lib/mcollective/discovery/choria.rb
+++ b/lib/mcollective/discovery/choria.rb
@@ -61,7 +61,7 @@ module MCollective
       # @param filter [String] a collective name
       # @return [String] a query string
       def discover_collective(filter)
-        'certname in inventory[certname] { facts.mcollective.server.collectives.match("\d+") = "%s" }' % filter
+        nil
       end
 
       # Searches for facts


### PR DESCRIPTION
After adjusting the repo to fix discovery using PuppetDB, I got
exceptions when trying to find nodes: PuppetDB would raise an
org.postgresql.util.PSQLException: related to an invalid syntax.

The `mcollective.server` facts where removed some time ago:
https://github.com/choria-io/puppet-mcollective/pull/268

I have no experience with subcollectives so this is only a workaround and a way to start a discussion for a proper way to fix this.